### PR TITLE
ci: add commitlint job

### DIFF
--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -13,7 +13,6 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v3
 
@@ -44,6 +43,25 @@ jobs:
         with:
           name: bucketeer-build-reports
           path: bucketeer/build/reports
+
+
+  commitlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16.x
+
+      - name: Install commitlint
+        run: npm install @commitlint/cli @commitlint/config-conventional
+
+      - name: Check commit messages
+        run: npx commitlint --from ${{ github.event.pull_request.base.sha }} --to ${{ github.event.pull_request.head.sha }} --verbose
 
 env:
   GRADLE_OPTS: -Dorg.gradle.daemon=false -Dorg.gradle.configureondemand=true -Dkotlin.incremental=false -Dorg.gradle.jvmargs="-XX:+HeapDumpOnOutOfMemoryError -XX:MetaspaceSize=1g"

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ build
 
 *.hprof
 *.gpg
+
+node_modules

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,1 @@
+module.exports = { extends: ['@commitlint/config-conventional'] }


### PR DESCRIPTION
To enforce [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) described in [CONTRIBUTING.md](https://github.com/bucketeer-io/android-client-sdk/blob/main/CONTRIBUTING.md), I've added commitlint check to CI.

failed: https://github.com/yshrsmz/android-client-sdk/actions/runs/3094712074/jobs/5008378745
succeeded: https://github.com/yshrsmz/android-client-sdk/actions/runs/3094871512/jobs/5008697637 