### PR TITLE
feat: evaluation update listener

### DIFF
--- a/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/BKTClient.kt
+++ b/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/BKTClient.kt
@@ -33,6 +33,12 @@ interface BKTClient {
 
   fun evaluationDetails(featureId: String): BKTEvaluation?
 
+  fun addEvaluationUpdateListener(listener: EvaluationUpdateListener): String
+
+  fun removeEvaluationUpdateListener(key: String)
+
+  fun clearEvaluationUpdateListeners()
+
   companion object {
 
     @Volatile
@@ -77,5 +83,10 @@ interface BKTClient {
         instance = null
       }
     }
+  }
+
+  fun interface EvaluationUpdateListener {
+    @MainThread
+    fun onUpdate()
   }
 }

--- a/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/BKTClientImpl.kt
+++ b/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/BKTClientImpl.kt
@@ -2,6 +2,8 @@ package io.bucketeer.sdk.android
 
 import android.app.Application
 import android.content.Context
+import android.os.Handler
+import android.os.Looper
 import androidx.annotation.MainThread
 import androidx.lifecycle.ProcessLifecycleOwner
 import io.bucketeer.sdk.android.internal.di.Component
@@ -32,7 +34,7 @@ internal class BKTClientImpl(
       user = user.toUser(),
       config = config,
     ),
-    interactorModule = InteractorModule(),
+    interactorModule = InteractorModule(mainHandler = Handler(Looper.getMainLooper())),
   ),
 ) : BKTClient {
 
@@ -104,6 +106,18 @@ internal class BKTClientImpl(
       variationValue = raw.variation_value,
       reason = BKTEvaluation.Reason.from(raw.reason.type.value),
     )
+  }
+
+  override fun addEvaluationUpdateListener(listener: BKTClient.EvaluationUpdateListener): String {
+    return component.evaluationInteractor.addUpdateListener(listener)
+  }
+
+  override fun removeEvaluationUpdateListener(key: String) {
+    component.evaluationInteractor.removeUpdateListener(key)
+  }
+
+  override fun clearEvaluationUpdateListeners() {
+    component.evaluationInteractor.clearUpdateListeners()
   }
 
   private fun refreshCache() {

--- a/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/di/Component.kt
+++ b/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/di/Component.kt
@@ -33,6 +33,7 @@ internal class ComponentImpl(
       apiClient = dataModule.apiClient,
       evaluationDao = dataModule.evaluationDao,
       sharedPreferences = dataModule.sharedPreferences,
+      idGenerator = dataModule.idGenerator,
     )
   }
 

--- a/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/di/InteractorModule.kt
+++ b/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/di/InteractorModule.kt
@@ -1,6 +1,7 @@
 package io.bucketeer.sdk.android.internal.di
 
 import android.content.SharedPreferences
+import android.os.Handler
 import io.bucketeer.sdk.android.internal.Clock
 import io.bucketeer.sdk.android.internal.IdGenerator
 import io.bucketeer.sdk.android.internal.evaluation.EvaluationInteractor
@@ -9,16 +10,21 @@ import io.bucketeer.sdk.android.internal.event.EventInteractor
 import io.bucketeer.sdk.android.internal.event.db.EventDao
 import io.bucketeer.sdk.android.internal.remote.ApiClient
 
-internal class InteractorModule {
+internal class InteractorModule(
+  val mainHandler: Handler,
+) {
   fun evaluationInteractor(
     apiClient: ApiClient,
     evaluationDao: EvaluationDao,
     sharedPreferences: SharedPreferences,
+    idGenerator: IdGenerator,
   ): EvaluationInteractor {
     return EvaluationInteractor(
       apiClient = apiClient,
       evaluationDao = evaluationDao,
       sharedPrefs = sharedPreferences,
+      idGenerator = idGenerator,
+      mainHandler = mainHandler,
     )
   }
 

--- a/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/internal/event/EventInteractorTest.kt
+++ b/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/internal/event/EventInteractorTest.kt
@@ -1,6 +1,8 @@
 package io.bucketeer.sdk.android.internal.event
 
 import android.app.Application
+import android.os.Handler
+import android.os.Looper
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import com.squareup.moshi.Moshi
@@ -66,7 +68,9 @@ class EventInteractorTest {
           .build(),
         defaultRequestTimeoutMillis = TimeUnit.SECONDS.toMillis(1),
       ),
-      interactorModule = InteractorModule(),
+      interactorModule = InteractorModule(
+        mainHandler = Handler(Looper.getMainLooper()),
+      ),
     )
 
     interactor = component.eventInteractor

--- a/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/internal/scheduler/EvaluationForegroundTaskTest.kt
+++ b/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/internal/scheduler/EvaluationForegroundTaskTest.kt
@@ -1,5 +1,7 @@
 package io.bucketeer.sdk.android.internal.scheduler
 
+import android.os.Handler
+import android.os.Looper
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import com.squareup.moshi.Moshi
@@ -49,7 +51,9 @@ class EvaluationForegroundTaskTest {
         user = user1,
         inMemoryDB = true,
       ),
-      interactorModule = InteractorModule(),
+      interactorModule = InteractorModule(
+        mainHandler = Handler(Looper.getMainLooper()),
+      ),
     )
 
     moshi = component.dataModule.moshi

--- a/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/internal/scheduler/EventForegroundTaskTest.kt
+++ b/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/internal/scheduler/EventForegroundTaskTest.kt
@@ -1,5 +1,7 @@
 package io.bucketeer.sdk.android.internal.scheduler
 
+import android.os.Handler
+import android.os.Looper
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import com.squareup.moshi.Moshi
@@ -52,7 +54,9 @@ class EventForegroundTaskTest {
         user = user1,
         inMemoryDB = true,
       ),
-      interactorModule = InteractorModule(),
+      interactorModule = InteractorModule(
+        mainHandler = Handler(Looper.getMainLooper()),
+      ),
     )
 
     moshi = component.dataModule.moshi


### PR DESCRIPTION
As background polling depends on BKTClient instance, update listeners can be called when evaluations are updated from background tasks.