### PR TITLE
ci: add PR title validation, remove commitlint

### DIFF
--- a/.github/workflows/pr-title-validation.yml
+++ b/.github/workflows/pr-title-validation.yml
@@ -1,0 +1,38 @@
+name: "pr-title-validation"
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  validate_pr_title:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v4
+        with:
+          # Use the following release types to match the same rules in the PR title lint
+          # https://github.com/googleapis/release-please/blob/main/src/changelog-notes.ts#L42-L55
+          types: |
+            feat
+            fix
+            perf
+            deps
+            revert
+            docs
+            style
+            chore
+            refactor
+            test
+            build
+            ci
+          subjectPattern: ^(?![A-Z]).+$
+          subjectPatternError: |
+            The subject "{subject}" found in the pull request title "{title}"
+            didn't match the configured pattern. Please ensure that the subject
+            doesn't start with an uppercase character.
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -44,24 +44,5 @@ jobs:
           name: bucketeer-build-reports
           path: bucketeer/build/reports
 
-
-  commitlint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-
-      - name: Setup Node
-        uses: actions/setup-node@v3
-        with:
-          node-version: 16.x
-
-      - name: Install commitlint
-        run: npm install @commitlint/cli @commitlint/config-conventional
-
-      - name: Check commit messages
-        run: npx commitlint --from ${{ github.event.pull_request.base.sha }} --to ${{ github.event.pull_request.head.sha }} --verbose
-
 env:
   GRADLE_OPTS: -Dorg.gradle.daemon=false -Dorg.gradle.configureondemand=true -Dkotlin.incremental=false -Dorg.gradle.jvmargs="-XX:+HeapDumpOnOutOfMemoryError -XX:MetaspaceSize=1g"

--- a/.gitignore
+++ b/.gitignore
@@ -21,5 +21,3 @@ build
 
 *.hprof
 *.gpg
-
-node_modules

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,1 +1,0 @@
-module.exports = { extends: ['@commitlint/config-conventional'] }


### PR DESCRIPTION
There are a few concerns regarding squash merge though:

- Single PR can not include multiple changelog entries
  - This happens when a feature needs a library update.
- Admins need to add an optional body & footer(for example, breaking change) to final squash commit, which people easily forget.