### PR TITLE
feat: rename setUserAttributes interface to updateUserAttributes

### DIFF
--- a/bucketeer/src/androidTest/kotlin/io/bucketeer/sdk/android/e2e/BKTClientTest.kt
+++ b/bucketeer/src/androidTest/kotlin/io/bucketeer/sdk/android/e2e/BKTClientTest.kt
@@ -62,7 +62,7 @@ class BKTClientTest {
     assertThat(client.stringVariation(FEATURE_ID_STRING, ""))
       .isEqualTo("value-1")
 
-    client.setUserAttributes(mapOf("app_version" to "0.0.1"))
+    client.updateUserAttributes(mapOf("app_version" to "0.0.1"))
 
     client.fetchEvaluations().get()
 

--- a/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/BKTClient.kt
+++ b/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/BKTClient.kt
@@ -25,7 +25,7 @@ interface BKTClient {
 
   fun currentUser(): BKTUser
 
-  fun setUserAttributes(attributes: Map<String, String>)
+  fun updateUserAttributes(attributes: Map<String, String>)
 
   fun fetchEvaluations(timeoutMillis: Long? = null): Future<BKTException?>
 

--- a/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/BKTClientImpl.kt
+++ b/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/BKTClientImpl.kt
@@ -77,7 +77,7 @@ internal class BKTClientImpl(
     return component.userHolder.get().toBKTUser()
   }
 
-  override fun setUserAttributes(attributes: Map<String, String>) {
+  override fun updateUserAttributes(attributes: Map<String, String>) {
     component.userHolder.updateAttributes { attributes }
   }
 

--- a/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/BKTClientImplTest.kt
+++ b/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/BKTClientImplTest.kt
@@ -632,7 +632,7 @@ class BKTClientImplTest {
       "custom_key_2" to "custom_key_value_2",
     )
 
-    BKTClient.getInstance().setUserAttributes(attributes)
+    BKTClient.getInstance().updateUserAttributes(attributes)
 
     assertThat(BKTClient.getInstance().currentUser())
       .isEqualTo(user1.toBKTUser().copy(attributes = attributes))


### PR DESCRIPTION
Because we refer to how to update the user attributes in the documentation, I think it will be better to use the word `update` instead of `set` for this case. 
The user attributes are set when the SDK is initialized, so it makes more sense to call as an update instead of a set.