### PR TITLE
chore: rename endpoint config to apiEndpoint

### DIFF
--- a/bucketeer/src/androidTest/kotlin/io/bucketeer/sdk/android/e2e/BKTClientEventTest.kt
+++ b/bucketeer/src/androidTest/kotlin/io/bucketeer/sdk/android/e2e/BKTClientEventTest.kt
@@ -31,7 +31,7 @@ class BKTClientEventTest {
 
     config = BKTConfig.builder()
       .apiKey(BuildConfig.API_KEY)
-      .endpoint(BuildConfig.API_ENDPOINT)
+      .apiEndpoint(BuildConfig.API_ENDPOINT)
       .featureTag(FEATURE_TAG)
       .build()
 

--- a/bucketeer/src/androidTest/kotlin/io/bucketeer/sdk/android/e2e/BKTClientTest.kt
+++ b/bucketeer/src/androidTest/kotlin/io/bucketeer/sdk/android/e2e/BKTClientTest.kt
@@ -31,7 +31,7 @@ class BKTClientTest {
 
     config = BKTConfig.builder()
       .apiKey(BuildConfig.API_KEY)
-      .endpoint(BuildConfig.API_ENDPOINT)
+      .apiEndpoint(BuildConfig.API_ENDPOINT)
       .featureTag(FEATURE_TAG)
       .build()
 

--- a/bucketeer/src/androidTest/kotlin/io/bucketeer/sdk/android/e2e/BKTClientVariationTest.kt
+++ b/bucketeer/src/androidTest/kotlin/io/bucketeer/sdk/android/e2e/BKTClientVariationTest.kt
@@ -32,7 +32,7 @@ class BKTClientVariationTest {
 
     config = BKTConfig.builder()
       .apiKey(BuildConfig.API_KEY)
-      .endpoint(BuildConfig.API_ENDPOINT)
+      .apiEndpoint(BuildConfig.API_ENDPOINT)
       .featureTag(FEATURE_TAG)
       .build()
 

--- a/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/BKTConfig.kt
+++ b/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/BKTConfig.kt
@@ -14,7 +14,7 @@ internal const val DEFAULT_BACKGROUND_POLLING_INTERVAL_MILLIS: Long = 3_600_000 
 
 data class BKTConfig internal constructor(
   val apiKey: String,
-  val endpoint: String,
+  val apiEndpoint: String,
   val featureTag: String,
   val eventsFlushInterval: Long,
   val eventsMaxBatchQueueCount: Int,
@@ -29,7 +29,7 @@ data class BKTConfig internal constructor(
 
   class Builder internal constructor() {
     private var apiKey: String? = null
-    private var endpoint: String? = null
+    private var apiEndpoint: String? = null
     private var featureTag: String? = null
     private var eventsFlushInterval: Long = DEFAULT_FLUSH_INTERVAL_MILLIS
     private var eventsMaxQueueSize: Int = DEFAULT_MAX_QUEUE_SIZE
@@ -42,8 +42,8 @@ data class BKTConfig internal constructor(
       return this
     }
 
-    fun endpoint(endpoint: String): Builder {
-      this.endpoint = endpoint
+    fun apiEndpoint(apiEndpoint: String): Builder {
+      this.apiEndpoint = apiEndpoint
       return this
     }
 
@@ -79,7 +79,7 @@ data class BKTConfig internal constructor(
 
     fun build(): BKTConfig {
       require(!this.apiKey.isNullOrEmpty()) { "apiKey is required" }
-      require(this.endpoint?.toHttpUrlOrNull() != null) { "endpoint is invalid" }
+      require(this.apiEndpoint?.toHttpUrlOrNull() != null) { "apiEndpoint is invalid" }
       require(!this.featureTag.isNullOrEmpty()) { "featureTag is required" }
 
       if (this.pollingInterval < MINIMUM_POLLING_INTERVAL_MILLIS) {
@@ -99,7 +99,7 @@ data class BKTConfig internal constructor(
 
       return BKTConfig(
         apiKey = this.apiKey!!,
-        endpoint = this.endpoint!!,
+        apiEndpoint = this.apiEndpoint!!,
         featureTag = this.featureTag!!,
         eventsFlushInterval = this.eventsFlushInterval,
         eventsMaxBatchQueueCount = this.eventsMaxQueueSize,

--- a/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/di/DataModule.kt
+++ b/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/di/DataModule.kt
@@ -44,7 +44,7 @@ internal open class DataModule(
 
   open val apiClient: ApiClient by lazy {
     ApiClientImpl(
-      endpoint = config.endpoint,
+      apiEndpoint = config.apiEndpoint,
       apiKey = config.apiKey,
       featureTag = config.featureTag,
       moshi = moshi,

--- a/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/remote/ApiClientImpl.kt
+++ b/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/remote/ApiClientImpl.kt
@@ -24,14 +24,14 @@ import java.util.concurrent.TimeUnit
 internal const val DEFAULT_REQUEST_TIMEOUT_MILLIS: Long = 30_000
 
 internal class ApiClientImpl(
-  endpoint: String,
+  apiEndpoint: String,
   private val apiKey: String,
   private val featureTag: String,
   private val moshi: Moshi,
   defaultRequestTimeoutMillis: Long = DEFAULT_REQUEST_TIMEOUT_MILLIS,
 ) : ApiClient {
 
-  private val endpoint = endpoint.toHttpUrl()
+  private val apiEndpoint = apiEndpoint.toHttpUrl()
 
   private val client: OkHttpClient = OkHttpClient.Builder()
     .addNetworkInterceptor(FixJsonContentTypeInterceptor())
@@ -55,7 +55,7 @@ internal class ApiClientImpl(
 
     val request = Request.Builder()
       .url(
-        endpoint.newBuilder()
+        apiEndpoint.newBuilder()
           .addPathSegments("v1/gateway/evaluations")
           .build(),
       )
@@ -111,7 +111,7 @@ internal class ApiClientImpl(
 
     val request = Request.Builder()
       .url(
-        endpoint.newBuilder()
+        apiEndpoint.newBuilder()
           .addPathSegments("v1/gateway/events")
           .build(),
       )

--- a/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/BKTClientImplTest.kt
+++ b/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/BKTClientImplTest.kt
@@ -46,7 +46,7 @@ class BKTClientImplTest {
     server = MockWebServer()
 
     config = BKTConfig.builder()
-      .endpoint(server.url("").toString())
+      .apiEndpoint(server.url("").toString())
       .apiKey("api_key_value")
       .featureTag("feature_tag_value")
       .build()

--- a/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/BKTConfigTest.kt
+++ b/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/BKTConfigTest.kt
@@ -9,14 +9,14 @@ class BKTConfigTest {
   fun build() {
     val actual = BKTConfig.builder()
       .apiKey("api-key")
-      .endpoint("https://example.com")
+      .apiEndpoint("https://example.com")
       .featureTag("feature-tag")
       .build()
 
     assertThat(actual).isEqualTo(
       BKTConfig(
         apiKey = "api-key",
-        endpoint = "https://example.com",
+        apiEndpoint = "https://example.com",
         featureTag = "feature-tag",
         eventsFlushInterval = DEFAULT_FLUSH_INTERVAL_MILLIS,
         eventsMaxBatchQueueCount = DEFAULT_MAX_QUEUE_SIZE,
@@ -31,7 +31,7 @@ class BKTConfigTest {
   fun `apiKey - unset`() {
     val error = assertThrows(BKTException.IllegalArgumentException::class.java) {
       BKTConfig.builder()
-        .endpoint("https://example.com")
+        .apiEndpoint("https://example.com")
         .featureTag("feature-tag")
         .build()
     }
@@ -44,7 +44,7 @@ class BKTConfigTest {
     val error = assertThrows(BKTException.IllegalArgumentException::class.java) {
       BKTConfig.builder()
         .apiKey("")
-        .endpoint("https://example.com")
+        .apiEndpoint("https://example.com")
         .featureTag("feature-tag")
         .build()
     }
@@ -61,7 +61,7 @@ class BKTConfigTest {
         .build()
     }
 
-    assertThat(error).hasMessageThat().isEqualTo("endpoint is invalid")
+    assertThat(error).hasMessageThat().isEqualTo("apiEndpoint is invalid")
   }
 
   @Test
@@ -69,12 +69,12 @@ class BKTConfigTest {
     val error = assertThrows(BKTException.IllegalArgumentException::class.java) {
       BKTConfig.builder()
         .apiKey("api-key")
-        .endpoint("some invalid value")
+        .apiEndpoint("some invalid value")
         .featureTag("feature-tag")
         .build()
     }
 
-    assertThat(error).hasMessageThat().isEqualTo("endpoint is invalid")
+    assertThat(error).hasMessageThat().isEqualTo("apiEndpoint is invalid")
   }
 
   @Test
@@ -82,7 +82,7 @@ class BKTConfigTest {
     val error = assertThrows(BKTException.IllegalArgumentException::class.java) {
       BKTConfig.builder()
         .apiKey("api-key")
-        .endpoint("https://example.com")
+        .apiEndpoint("https://example.com")
         .build()
     }
 
@@ -94,7 +94,7 @@ class BKTConfigTest {
     val error = assertThrows(BKTException.IllegalArgumentException::class.java) {
       BKTConfig.builder()
         .apiKey("api-key")
-        .endpoint("https://example.com")
+        .apiEndpoint("https://example.com")
         .featureTag("")
         .build()
     }
@@ -106,7 +106,7 @@ class BKTConfigTest {
   fun eventsFlushInterval() {
     val actual = BKTConfig.builder()
       .apiKey("api-key")
-      .endpoint("https://example.com")
+      .apiEndpoint("https://example.com")
       .featureTag("feature-tag")
       .eventsFlushInterval(70_000)
       .build()
@@ -118,7 +118,7 @@ class BKTConfigTest {
   fun `eventsFlushInterval - sooner than min value`() {
     val actual = BKTConfig.builder()
       .apiKey("api-key")
-      .endpoint("https://example.com")
+      .apiEndpoint("https://example.com")
       .featureTag("feature-tag")
       .eventsFlushInterval(10)
       .build()
@@ -130,7 +130,7 @@ class BKTConfigTest {
   fun pollingInterval() {
     val actual = BKTConfig.builder()
       .apiKey("api-key")
-      .endpoint("https://example.com")
+      .apiEndpoint("https://example.com")
       .featureTag("feature-tag")
       .pollingInterval(70_000)
       .build()
@@ -142,7 +142,7 @@ class BKTConfigTest {
   fun `pollingInterval - sooner than min value`() {
     val actual = BKTConfig.builder()
       .apiKey("api-key")
-      .endpoint("https://example.com")
+      .apiEndpoint("https://example.com")
       .featureTag("feature-tag")
       .pollingInterval(10)
       .build()
@@ -154,7 +154,7 @@ class BKTConfigTest {
   fun backgroundPollingInterval() {
     val actual = BKTConfig.builder()
       .apiKey("api-key")
-      .endpoint("https://example.com")
+      .apiEndpoint("https://example.com")
       .featureTag("feature-tag")
       .backgroundPollingInterval(1_300_000)
       .build()
@@ -167,7 +167,7 @@ class BKTConfigTest {
   fun `backgroundPollingInterval - sooner than min value`() {
     val actual = BKTConfig.builder()
       .apiKey("api-key")
-      .endpoint("https://example.com")
+      .apiEndpoint("https://example.com")
       .featureTag("feature-tag")
       .backgroundPollingInterval(10)
       .build()
@@ -180,7 +180,7 @@ class BKTConfigTest {
   fun `logger - can be null`() {
     val actual = BKTConfig.builder()
       .apiKey("api-key")
-      .endpoint("https://example.com")
+      .apiEndpoint("https://example.com")
       .featureTag("feature-tag")
       .logger(null)
       .build()
@@ -188,7 +188,7 @@ class BKTConfigTest {
     assertThat(actual).isEqualTo(
       BKTConfig(
         apiKey = "api-key",
-        endpoint = "https://example.com",
+        apiEndpoint = "https://example.com",
         featureTag = "feature-tag",
         eventsFlushInterval = DEFAULT_FLUSH_INTERVAL_MILLIS,
         eventsMaxBatchQueueCount = DEFAULT_MAX_QUEUE_SIZE,

--- a/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/TestHelpers.kt
+++ b/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/TestHelpers.kt
@@ -38,7 +38,7 @@ internal inline fun <reified T> MockWebServer.enqueueResponse(
  */
 internal fun createTestBKTConfig(
   apiKey: String,
-  endpoint: String,
+  apiEndpoint: String,
   featureTag: String,
   eventsFlushInterval: Long = DEFAULT_FLUSH_INTERVAL_MILLIS,
   eventsMaxBatchQueueCount: Int = DEFAULT_MAX_QUEUE_SIZE,
@@ -48,7 +48,7 @@ internal fun createTestBKTConfig(
 ): BKTConfig {
   return BKTConfig(
     apiKey = apiKey,
-    endpoint = endpoint,
+    apiEndpoint = apiEndpoint,
     featureTag = featureTag,
     eventsFlushInterval = eventsFlushInterval,
     eventsMaxBatchQueueCount = eventsMaxBatchQueueCount,

--- a/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/internal/evaluation/EvaluationInteractorTest.kt
+++ b/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/internal/evaluation/EvaluationInteractorTest.kt
@@ -48,7 +48,7 @@ class EvaluationInteractorTest {
         application = ApplicationProvider.getApplicationContext(),
         user = user1,
         config = BKTConfig.builder()
-          .endpoint(server.url("").toString())
+          .apiEndpoint(server.url("").toString())
           .apiKey("api_key_value")
           .featureTag("feature_tag_value")
           .build(),

--- a/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/internal/event/EventInteractorTest.kt
+++ b/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/internal/event/EventInteractorTest.kt
@@ -61,7 +61,7 @@ class EventInteractorTest {
       dataModule = TestDataModule(
         application = ApplicationProvider.getApplicationContext(),
         config = BKTConfig.builder()
-          .endpoint(server.url("").toString())
+          .apiEndpoint(server.url("").toString())
           .apiKey("api_key_value")
           .featureTag("feature_tag_value")
           .eventsMaxQueueSize(3)
@@ -704,7 +704,7 @@ private class TestDataModule(
 
   override val apiClient: ApiClient by lazy {
     ApiClientImpl(
-      endpoint = config.endpoint,
+      apiEndpoint = config.apiEndpoint,
       apiKey = config.apiKey,
       featureTag = config.featureTag,
       moshi = moshi,

--- a/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/internal/remote/ApiClientImplTest.kt
+++ b/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/internal/remote/ApiClientImplTest.kt
@@ -76,7 +76,7 @@ internal class ApiClientImplTest {
     )
 
     client = ApiClientImpl(
-      endpoint = endpoint,
+      apiEndpoint = endpoint,
       apiKey = "api_key_value",
       featureTag = "feature_tag_value",
       moshi = moshi,
@@ -116,7 +116,7 @@ internal class ApiClientImplTest {
   @Test
   fun `getEvaluations - default timeout`() {
     client = ApiClientImpl(
-      endpoint = endpoint,
+      apiEndpoint = endpoint,
       apiKey = "api_key_value",
       featureTag = "feature_tag_value",
       moshi = moshi,
@@ -143,7 +143,7 @@ internal class ApiClientImplTest {
   @Test
   fun `getEvaluations - custom timeout`() {
     client = ApiClientImpl(
-      endpoint = endpoint,
+      apiEndpoint = endpoint,
       apiKey = "api_key_value",
       featureTag = "feature_tag_value",
       moshi = moshi,
@@ -170,7 +170,7 @@ internal class ApiClientImplTest {
   @Test
   fun `getEvaluations - network error`() {
     client = ApiClientImpl(
-      endpoint = "https://thisdoesnotexist.bucketeer.io",
+      apiEndpoint = "https://thisdoesnotexist.bucketeer.io",
       apiKey = "api_key_value",
       featureTag = "feature_tag_value",
       moshi = moshi,
@@ -206,7 +206,7 @@ internal class ApiClientImplTest {
         ),
     )
     client = ApiClientImpl(
-      endpoint = endpoint,
+      apiEndpoint = endpoint,
       apiKey = "api_key_value",
       featureTag = "feature_tag_value",
       moshi = moshi,
@@ -233,7 +233,7 @@ internal class ApiClientImplTest {
         .setBody("error: ${case.code}"),
     )
     client = ApiClientImpl(
-      endpoint = endpoint,
+      apiEndpoint = endpoint,
       apiKey = "api_key_value",
       featureTag = "feature_tag_value",
       moshi = moshi,
@@ -274,7 +274,7 @@ internal class ApiClientImplTest {
         ),
     )
     client = ApiClientImpl(
-      endpoint = endpoint,
+      apiEndpoint = endpoint,
       apiKey = "api_key_value",
       featureTag = "feature_tag_value",
       moshi = moshi,
@@ -312,7 +312,7 @@ internal class ApiClientImplTest {
   @Test
   fun `registerEvents - timeout`() {
     client = ApiClientImpl(
-      endpoint = endpoint,
+      apiEndpoint = endpoint,
       apiKey = "api_key_value",
       featureTag = "feature_tag_value",
       moshi = moshi,
@@ -335,7 +335,7 @@ internal class ApiClientImplTest {
   @Test
   fun `registerEvents - network error`() {
     client = ApiClientImpl(
-      endpoint = "https://thisdoesnotexist.bucketeer.io",
+      apiEndpoint = "https://thisdoesnotexist.bucketeer.io",
       apiKey = "api_key_value",
       featureTag = "feature_tag_value",
       moshi = moshi,
@@ -367,7 +367,7 @@ internal class ApiClientImplTest {
         ),
     )
     client = ApiClientImpl(
-      endpoint = endpoint,
+      apiEndpoint = endpoint,
       apiKey = "api_key_value",
       featureTag = "feature_tag_value",
       moshi = moshi,
@@ -391,7 +391,7 @@ internal class ApiClientImplTest {
         .setBody("error: ${case.code}"),
     )
     client = ApiClientImpl(
-      endpoint = endpoint,
+      apiEndpoint = endpoint,
       apiKey = "api_key_value",
       featureTag = "feature_tag_value",
       moshi = moshi,

--- a/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/internal/scheduler/EvaluationBackgroundTaskTest.kt
+++ b/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/internal/scheduler/EvaluationBackgroundTaskTest.kt
@@ -34,7 +34,7 @@ class EvaluationBackgroundTaskTest {
 
     config = createTestBKTConfig(
       apiKey = "api_key_value",
-      endpoint = server.url("").toString(),
+      apiEndpoint = server.url("").toString(),
       featureTag = "feature_tag_value",
     )
 

--- a/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/internal/scheduler/EvaluationForegroundTaskTest.kt
+++ b/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/internal/scheduler/EvaluationForegroundTaskTest.kt
@@ -43,7 +43,7 @@ class EvaluationForegroundTaskTest {
         application = ApplicationProvider.getApplicationContext(),
         config = createTestBKTConfig(
           apiKey = "api_key_value",
-          endpoint = server.url("").toString(),
+          apiEndpoint = server.url("").toString(),
           featureTag = "feature_tag_value",
           eventsMaxBatchQueueCount = 3,
           pollingInterval = 1000,

--- a/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/internal/scheduler/EventBackgroundTaskTest.kt
+++ b/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/internal/scheduler/EventBackgroundTaskTest.kt
@@ -33,7 +33,7 @@ class EventBackgroundTaskTest {
 
     config = createTestBKTConfig(
       apiKey = "api_key_value",
-      endpoint = server.url("").toString(),
+      apiEndpoint = server.url("").toString(),
       featureTag = "feature_tag_value",
     )
 

--- a/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/internal/scheduler/EventForegroundTaskTest.kt
+++ b/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/internal/scheduler/EventForegroundTaskTest.kt
@@ -46,7 +46,7 @@ class EventForegroundTaskTest {
         application = ApplicationProvider.getApplicationContext(),
         config = createTestBKTConfig(
           apiKey = "api_key_value",
-          endpoint = server.url("").toString(),
+          apiEndpoint = server.url("").toString(),
           featureTag = "feature_tag_value",
           eventsMaxBatchQueueCount = 3,
           eventsFlushInterval = 1000,

--- a/sample/src/main/java/io/bucketeer/sample/App.kt
+++ b/sample/src/main/java/io/bucketeer/sample/App.kt
@@ -32,7 +32,7 @@ class App : Application(), LifecycleObserver {
   private fun initBucketeer() {
     val config = BKTConfig.builder()
       .apiKey(BuildConfig.API_KEY)
-      .endpoint(BuildConfig.API_ENDPOINT)
+      .apiEndpoint(BuildConfig.API_ENDPOINT)
       .featureTag(getTag())
       .eventsMaxQueueSize(10)
       .pollingInterval(TimeUnit.SECONDS.toMillis(20))


### PR DESCRIPTION
Because we use the api prefix in the `apiKey`, it will be better to match using the prefix in the endpoint config for easy understanding.