### PR TITLE
ci: group Kotlin & ksp

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -49,5 +49,5 @@ kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin-kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin" }
 kotlin-dokka = { id = "org.jetbrains.dokka", version = "1.7.20" }
 publish = { id = "com.vanniktech.maven.publish", version = "0.22.0" }
-ksp = { id = "com.google.devtools.ksp", version = "1.7.20-1.0.6" }
+ksp = { id = "com.google.devtools.ksp", version = "1.7.22-1.0.8" }
 kotlinter = { id = "org.jmailen.kotlinter", version = "3.13.0" }

--- a/renovate.json
+++ b/renovate.json
@@ -4,5 +4,15 @@
     "config:base",
     ":timezone(Asia/Tokyo)",
     "schedule:monthly"
+  ],
+  "packageRules": [
+    {
+      "groupName": "Kotlin",
+      "matchPackagePatterns": [
+        "^org\\.jetbrains\\.kotlin:",
+        "^org\\.jetbrains\\.kotlin\\.",
+        "^com\\.google\\.devtools\\.ksp"
+      ]
+    }
   ]
 }


### PR DESCRIPTION
- update renovate.config to group Kotlin & ksp updates
  - ksp has a dedicated artifact for each Kotlin version
- updated ksp to v1.7.22-1.0.8