### PR TITLE
feat: prevent logging duplicate event data

### DIFF
--- a/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/event/EventInteractor.kt
+++ b/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/event/EventInteractor.kt
@@ -100,8 +100,8 @@ internal class EventInteractor(
 
   /*
    * Method addMetricEvents()
-   * Will filter duplicate metric event by finding existed metrics event on the cache database
-   * Remove all existed metrics event, only add new metrics event
+   * Will filter duplicate metric events by finding existing metrics events on the cache database fist
+   * Remove all new duplicate metrics events, only add new metrics event
    * @params events: should be a list of `EventData.MetricsEvent`
    */
   @VisibleForTesting

--- a/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/event/EventInteractor.kt
+++ b/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/event/EventInteractor.kt
@@ -1,5 +1,6 @@
 package io.bucketeer.sdk.android.internal.event
 
+import androidx.annotation.VisibleForTesting
 import io.bucketeer.sdk.android.BKTException
 import io.bucketeer.sdk.android.internal.Clock
 import io.bucketeer.sdk.android.internal.IdGenerator
@@ -8,6 +9,7 @@ import io.bucketeer.sdk.android.internal.logd
 import io.bucketeer.sdk.android.internal.model.ApiId
 import io.bucketeer.sdk.android.internal.model.Evaluation
 import io.bucketeer.sdk.android.internal.model.Event
+import io.bucketeer.sdk.android.internal.model.EventData
 import io.bucketeer.sdk.android.internal.model.User
 import io.bucketeer.sdk.android.internal.remote.ApiClient
 import io.bucketeer.sdk.android.internal.remote.RegisterEventsResult
@@ -59,19 +61,16 @@ internal class EventInteractor(
   ) {
     // For get_evaluations, we will report all metrics events, Including the latency and size metrics events.
     // https://github.com/bucketeer-io/android-client-sdk/issues/56
-    eventDao.addEvents(
-      newSuccessMetricsEvents(
-        clock = clock,
-        idGenerator = idGenerator,
-        featureTag = featureTag,
-        appVersion = appVersion,
-        apiId = ApiId.GET_EVALUATIONS,
-        latencySecond = seconds,
-        sizeByte = sizeByte,
-      ),
+    val events = newSuccessMetricsEvents(
+      clock = clock,
+      idGenerator = idGenerator,
+      featureTag = featureTag,
+      appVersion = appVersion,
+      apiId = ApiId.GET_EVALUATIONS,
+      latencySecond = seconds,
+      sizeByte = sizeByte,
     )
-
-    updateEventsAndNotify()
+    addMetricEvents(events)
   }
 
   fun trackFetchEvaluationsFailure(
@@ -96,8 +95,40 @@ internal class EventInteractor(
       error = error,
       apiId = apiId,
     )
-    eventDao.addEvent(event)
-    updateEventsAndNotify()
+    addMetricEvents(listOf(event))
+  }
+
+  /*
+   * Method addMetricEvents()
+   * Will filter duplicate metric event by finding existed metrics event on the cache database
+   * Remove all existed metrics event, only add new metrics event
+   * @params events: should be a list of `EventData.MetricsEvent`
+   */
+  @VisibleForTesting
+  internal fun addMetricEvents(
+    events: List<Event>,
+  ) {
+    // 1 Get all event
+    // 2 Get metrics data unique key
+    // 3 Filter the list
+    // 4 If list is not empty -> add to database
+    val storedEvents = eventDao.getEvents()
+    val metricsEventUniqueKeys: List<String> = storedEvents.filter {
+      it.event is EventData.MetricsEvent
+    }.map {
+      val metricsEvent = it.event as EventData.MetricsEvent
+      return@map metricsEvent.uniqueKey()
+    }
+
+    // For get_evaluations, we will report all metrics events, Including the latency and size metrics events.
+    // https://github.com/bucketeer-io/android-client-sdk/issues/56
+    val newEvents = events.filter {
+      it.event is EventData.MetricsEvent && !metricsEventUniqueKeys.contains(it.event.uniqueKey())
+    }
+    if (newEvents.isNotEmpty()) {
+      eventDao.addEvents(newEvents)
+      updateEventsAndNotify()
+    }
   }
 
   fun sendEvents(force: Boolean = false): SendEventsResult {

--- a/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/event/EventInteractor.kt
+++ b/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/event/EventInteractor.kt
@@ -113,13 +113,9 @@ internal class EventInteractor(
     // 3 Filter the list
     // 4 If list is not empty -> add to database
     val storedEvents = eventDao.getEvents()
-    val metricsEventUniqueKeys: List<String> = storedEvents.filter {
-      it.event is EventData.MetricsEvent
-    }.map {
-      val metricsEvent = it.event as EventData.MetricsEvent
-      return@map metricsEvent.uniqueKey()
-    }
-
+    val metricsEventUniqueKeys: List<String> = storedEvents
+      .filter { it.event is EventData.MetricsEvent }
+      .map { (it.event as EventData.MetricsEvent).uniqueKey() }
     // For get_evaluations, we will report all metrics events, Including the latency and size metrics events.
     // https://github.com/bucketeer-io/android-client-sdk/issues/56
     val newEvents = events.filter {

--- a/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/event/db/EventDaoImpl.kt
+++ b/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/event/db/EventDaoImpl.kt
@@ -37,10 +37,10 @@ internal class EventDaoImpl(
       it.event.hashCode()
     }
     sqLiteOpenHelper.writableDatabase.transaction {
-      events.forEach { event ->
+      events.forEach { item ->
         // 2. Push to the database when the event data do not exist in the database
-        if (!storedEventHashList.contains(event.event.hashCode())) {
-          addEventInternal(this, event)
+        if (!storedEventHashList.contains(item.event.hashCode())) {
+          addEventInternal(this, item)
         }
       }
     }

--- a/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/event/db/EventDaoImpl.kt
+++ b/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/event/db/EventDaoImpl.kt
@@ -12,7 +12,6 @@ import io.bucketeer.sdk.android.internal.database.transaction
 import io.bucketeer.sdk.android.internal.event.EventEntity.Companion.COLUMN_EVENT
 import io.bucketeer.sdk.android.internal.event.EventEntity.Companion.COLUMN_ID
 import io.bucketeer.sdk.android.internal.event.EventEntity.Companion.TABLE_NAME
-import io.bucketeer.sdk.android.internal.logd
 import io.bucketeer.sdk.android.internal.model.Event
 
 internal class EventDaoImpl(
@@ -42,8 +41,6 @@ internal class EventDaoImpl(
         // 2. Push to the database when the event data do not exist in the database
         if (!storedEventHashList.contains(item.event.hashCode())) {
           addEventInternal(this, item)
-        } else {
-          logd { "Duplicate" }
         }
       }
     }

--- a/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/event/db/EventDaoImpl.kt
+++ b/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/event/db/EventDaoImpl.kt
@@ -31,8 +31,6 @@ internal class EventDaoImpl(
     // It could be better but This approach will create a minimum impact,
     // And because the number of pending events in the database is small
     // So I think we are safe to do this without changing too much
-    // 1. Get all current events and collect hash
-    // https://kotlinlang.org/docs/data-classes.html
     val storedEvents = getEvents()
     val storedEventHashList: List<String> = storedEvents.filter {
       it.event is EventData.MetricsEvent

--- a/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/event/db/EventDaoImpl.kt
+++ b/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/event/db/EventDaoImpl.kt
@@ -32,7 +32,7 @@ internal class EventDaoImpl(
     // And because the number of pending events in the database is small
     // So I think we are safe to do this without changing too much
     val storedEvents = getEvents()
-    val storedEventHashList: List<String> = storedEvents.filter {
+    val metricsEventUniqueKeys: List<String> = storedEvents.filter {
       it.event is EventData.MetricsEvent
     }.map {
       val metricEvent = it.event as EventData.MetricsEvent
@@ -44,7 +44,7 @@ internal class EventDaoImpl(
         when (item.event) {
           is EventData.MetricsEvent -> {
             // 2. Push to the database when the event data do not exist in the database
-            if (!storedEventHashList.contains(item.event.uniqueKey())) {
+            if (!metricsEventUniqueKeys.contains(item.event.uniqueKey())) {
               addEventInternal(this, item)
             }
           }

--- a/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/event/db/EventDaoImpl.kt
+++ b/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/event/db/EventDaoImpl.kt
@@ -35,8 +35,8 @@ internal class EventDaoImpl(
     val metricsEventUniqueKeys: List<String> = storedEvents.filter {
       it.event is EventData.MetricsEvent
     }.map {
-      val metricEvent = it.event as EventData.MetricsEvent
-      return@map metricEvent.uniqueKey()
+      val metricsEvent = it.event as EventData.MetricsEvent
+      return@map metricsEvent.uniqueKey()
     }
 
     sqLiteOpenHelper.writableDatabase.transaction {

--- a/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/event/db/EventDaoImpl.kt
+++ b/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/event/db/EventDaoImpl.kt
@@ -2,7 +2,6 @@ package io.bucketeer.sdk.android.internal.event.db
 
 import android.content.ContentValues
 import android.database.sqlite.SQLiteDatabase
-import android.util.Log
 import androidx.sqlite.db.SupportSQLiteDatabase
 import androidx.sqlite.db.SupportSQLiteOpenHelper
 import com.squareup.moshi.Moshi
@@ -27,22 +26,21 @@ internal class EventDaoImpl(
   }
 
   override fun addEvents(events: List<Event>) {
-    // This approach below is reference from iOS SDK.
-    // It may not better but it will create a minimum impact,
-    // And because number of pending event in database is small
+    // This approach below is a reference from iOS SDK.
+    // It could be better but This approach will create a minimum impact,
+    // And because the number of pending events in the database is small
     // So I think we are safe to do this without changing too much
     // 1. Get all current events and collect hash
+    // https://kotlinlang.org/docs/data-classes.html
     val storedEvents = getEvents()
     val storedEventHashList = storedEvents.map {
       it.event.hashCode()
     }
     sqLiteOpenHelper.writableDatabase.transaction {
       events.forEach { event ->
-        // 2. Push to database, Only when the event data is not exist in the database
+        // 2. Push to the database when the event data do not exist in the database
         if (!storedEventHashList.contains(event.event.hashCode())) {
           addEventInternal(this, event)
-        } else {
-          Log.i("DAO", "duplicate")
         }
       }
     }

--- a/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/event/db/EventDaoImpl.kt
+++ b/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/event/db/EventDaoImpl.kt
@@ -12,6 +12,7 @@ import io.bucketeer.sdk.android.internal.database.transaction
 import io.bucketeer.sdk.android.internal.event.EventEntity.Companion.COLUMN_EVENT
 import io.bucketeer.sdk.android.internal.event.EventEntity.Companion.COLUMN_ID
 import io.bucketeer.sdk.android.internal.event.EventEntity.Companion.TABLE_NAME
+import io.bucketeer.sdk.android.internal.logd
 import io.bucketeer.sdk.android.internal.model.Event
 
 internal class EventDaoImpl(
@@ -41,6 +42,8 @@ internal class EventDaoImpl(
         // 2. Push to the database when the event data do not exist in the database
         if (!storedEventHashList.contains(item.event.hashCode())) {
           addEventInternal(this, item)
+        } else {
+          logd { "Duplicate" }
         }
       }
     }

--- a/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/model/EventData.kt
+++ b/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/model/EventData.kt
@@ -6,7 +6,7 @@ import com.squareup.moshi.JsonClass
 // we can't use codegen here
 // see EventAdapterFactory
 sealed class EventData {
-
+  open val protobufType: String? = null
   @JsonClass(generateAdapter = true)
   data class GoalEvent(
     val timestamp: Long,
@@ -19,7 +19,7 @@ sealed class EventData {
     val sdkVersion: String? = null,
     val metadata: Map<String, String>? = null,
     @Json(name = "@type")
-    val protobufType: String? = "type.googleapis.com/bucketeer.event.client.GoalEvent",
+    override val protobufType: String? = "type.googleapis.com/bucketeer.event.client.GoalEvent",
   ) : EventData()
 
   @JsonClass(generateAdapter = true)
@@ -36,7 +36,7 @@ sealed class EventData {
     val sdkVersion: String? = null,
     val metadata: Map<String, String>? = null,
     @Json(name = "@type")
-    val protobufType: String? = "type.googleapis.com/bucketeer.event.client.EvaluationEvent",
+    override val protobufType: String? = "type.googleapis.com/bucketeer.event.client.EvaluationEvent",
   ) : EventData()
 
   // we can't use codegen here
@@ -48,6 +48,6 @@ sealed class EventData {
     val sdkVersion: String? = null,
     val metadata: Map<String, String>? = null,
     @Json(name = "@type")
-    val protobufType: String? = "type.googleapis.com/bucketeer.event.client.MetricsEvent",
+    override val protobufType: String? = "type.googleapis.com/bucketeer.event.client.MetricsEvent",
   ) : EventData()
 }

--- a/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/model/EventData.kt
+++ b/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/model/EventData.kt
@@ -1,9 +1,7 @@
 package io.bucketeer.sdk.android.internal.model
 
-import androidx.annotation.VisibleForTesting
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
-import io.bucketeer.sdk.android.BKTException
 
 // we can't use codegen here
 // see EventAdapterFactory
@@ -52,17 +50,8 @@ sealed class EventData {
     val protobufType: String? = "type.googleapis.com/bucketeer.event.client.MetricsEvent",
   ) : EventData() {
     // https://github.com/bucketeer-io/android-client-sdk/pull/68#discussion_r1222401661
-    fun uniqueKey() : String {
+    fun uniqueKey(): String {
       return "${event.apiId}::${event.protobufType}"
     }
   }
-}
-
-
-@VisibleForTesting
-internal fun Event.metricsEventUniqueKey() : String {
-  if (type == EventType.METRICS && event is EventData.MetricsEvent) {
-    return event.uniqueKey()
-  }
-  throw BKTException.IllegalStateException("expected `MetricsEvent` but the input is not")
 }

--- a/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/model/MetricsEventData.kt
+++ b/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/model/MetricsEventData.kt
@@ -4,8 +4,6 @@ import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 
 sealed class MetricsEventData {
-  abstract val protobufType: String?
-  abstract val apiId: ApiId
   @JsonClass(generateAdapter = true)
   data class LatencyMetricsEvent(
     override val apiId: ApiId,
@@ -112,4 +110,7 @@ sealed class MetricsEventData {
     @Json(name = "@type")
     override val protobufType: String? = "type.googleapis.com/bucketeer.event.client.UnknownErrorMetricsEvent",
   ) : MetricsEventData()
+
+  abstract val protobufType: String?
+  abstract val apiId: ApiId
 }

--- a/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/model/MetricsEventData.kt
+++ b/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/model/MetricsEventData.kt
@@ -4,6 +4,9 @@ import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 
 sealed class MetricsEventData {
+  abstract val protobufType: String?
+  abstract val apiId: ApiId
+
   @JsonClass(generateAdapter = true)
   data class LatencyMetricsEvent(
     override val apiId: ApiId,
@@ -110,7 +113,4 @@ sealed class MetricsEventData {
     @Json(name = "@type")
     override val protobufType: String? = "type.googleapis.com/bucketeer.event.client.UnknownErrorMetricsEvent",
   ) : MetricsEventData()
-
-  abstract val protobufType: String?
-  abstract val apiId: ApiId
 }

--- a/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/model/MetricsEventData.kt
+++ b/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/model/MetricsEventData.kt
@@ -4,111 +4,112 @@ import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 
 sealed class MetricsEventData {
-
+  abstract val protobufType: String?
+  abstract val apiId: ApiId
   @JsonClass(generateAdapter = true)
   data class LatencyMetricsEvent(
-    val apiId: ApiId,
+    override val apiId: ApiId,
     val labels: Map<String, String> = emptyMap(),
     // in seconds
     val latencySecond: Double,
     @Json(name = "@type")
-    val protobufType: String? = "type.googleapis.com/bucketeer.event.client.LatencyMetricsEvent",
+    override val protobufType: String? = "type.googleapis.com/bucketeer.event.client.LatencyMetricsEvent",
   ) : MetricsEventData()
 
   @JsonClass(generateAdapter = true)
   data class SizeMetricsEvent(
-    val apiId: ApiId,
+    override val apiId: ApiId,
     val labels: Map<String, String> = emptyMap(),
     val sizeByte: Int,
     @Json(name = "@type")
-    val protobufType: String? = "type.googleapis.com/bucketeer.event.client.SizeMetricsEvent",
+    override val protobufType: String? = "type.googleapis.com/bucketeer.event.client.SizeMetricsEvent",
   ) : MetricsEventData()
 
   @JsonClass(generateAdapter = true)
   data class TimeoutErrorMetricsEvent(
-    val apiId: ApiId,
+    override val apiId: ApiId,
     val labels: Map<String, String> = emptyMap(),
     @Json(name = "@type")
-    val protobufType: String? = "type.googleapis.com/bucketeer.event.client.TimeoutErrorMetricsEvent",
+    override val protobufType: String? = "type.googleapis.com/bucketeer.event.client.TimeoutErrorMetricsEvent",
   ) : MetricsEventData()
 
   @JsonClass(generateAdapter = true)
   data class NetworkErrorMetricsEvent(
-    val apiId: ApiId,
+    override val apiId: ApiId,
     val labels: Map<String, String> = emptyMap(),
     @Json(name = "@type")
-    val protobufType: String? = "type.googleapis.com/bucketeer.event.client.NetworkErrorMetricsEvent",
+    override val protobufType: String? = "type.googleapis.com/bucketeer.event.client.NetworkErrorMetricsEvent",
   ) : MetricsEventData()
 
   @JsonClass(generateAdapter = true)
   data class BadRequestErrorMetricsEvent(
-    val apiId: ApiId,
+    override val apiId: ApiId,
     val labels: Map<String, String> = emptyMap(),
     @Json(name = "@type")
-    val protobufType: String? = "type.googleapis.com/bucketeer.event.client.BadRequestErrorMetricsEvent",
+    override val protobufType: String? = "type.googleapis.com/bucketeer.event.client.BadRequestErrorMetricsEvent",
   ) : MetricsEventData()
 
   @JsonClass(generateAdapter = true)
   data class UnauthorizedErrorMetricsEvent(
-    val apiId: ApiId,
+    override val apiId: ApiId,
     val labels: Map<String, String> = emptyMap(),
     @Json(name = "@type")
-    val protobufType: String? = "type.googleapis.com/bucketeer.event.client.UnauthorizedErrorMetricsEvent",
+    override val protobufType: String? = "type.googleapis.com/bucketeer.event.client.UnauthorizedErrorMetricsEvent",
   ) : MetricsEventData()
 
   @JsonClass(generateAdapter = true)
   data class ForbiddenErrorMetricsEvent(
-    val apiId: ApiId,
+    override val apiId: ApiId,
     val labels: Map<String, String> = emptyMap(),
     @Json(name = "@type")
-    val protobufType: String? = "type.googleapis.com/bucketeer.event.client.ForbiddenErrorMetricsEvent",
+    override val protobufType: String? = "type.googleapis.com/bucketeer.event.client.ForbiddenErrorMetricsEvent",
   ) : MetricsEventData()
 
   @JsonClass(generateAdapter = true)
   data class NotFoundErrorMetricsEvent(
-    val apiId: ApiId,
+    override val apiId: ApiId,
     val labels: Map<String, String> = emptyMap(),
     @Json(name = "@type")
-    val protobufType: String? = "type.googleapis.com/bucketeer.event.client.NotFoundErrorMetricsEvent",
+    override val protobufType: String? = "type.googleapis.com/bucketeer.event.client.NotFoundErrorMetricsEvent",
   ) : MetricsEventData()
 
   @JsonClass(generateAdapter = true)
   data class ClientClosedRequestErrorMetricsEvent(
-    val apiId: ApiId,
+    override val apiId: ApiId,
     val labels: Map<String, String> = emptyMap(),
     @Json(name = "@type")
-    val protobufType: String? = "type.googleapis.com/bucketeer.event.client.ClientClosedRequestErrorMetricsEvent",
+    override val protobufType: String? = "type.googleapis.com/bucketeer.event.client.ClientClosedRequestErrorMetricsEvent",
   ) : MetricsEventData()
 
   @JsonClass(generateAdapter = true)
   data class ServiceUnavailableErrorMetricsEvent(
-    val apiId: ApiId,
+    override val apiId: ApiId,
     val labels: Map<String, String> = emptyMap(),
     @Json(name = "@type")
-    val protobufType: String? = "type.googleapis.com/bucketeer.event.client.ServiceUnavailableErrorMetricsEvent",
+    override val protobufType: String? = "type.googleapis.com/bucketeer.event.client.ServiceUnavailableErrorMetricsEvent",
   ) : MetricsEventData()
 
   @JsonClass(generateAdapter = true)
   data class InternalSdkErrorMetricsEvent(
-    val apiId: ApiId,
+    override val apiId: ApiId,
     val labels: Map<String, String> = emptyMap(),
     @Json(name = "@type")
-    val protobufType: String? = "type.googleapis.com/bucketeer.event.client.InternalSdkErrorMetricsEvent",
+    override val protobufType: String? = "type.googleapis.com/bucketeer.event.client.InternalSdkErrorMetricsEvent",
   ) : MetricsEventData()
 
   @JsonClass(generateAdapter = true)
   data class InternalServerErrorMetricsEvent(
-    val apiId: ApiId,
+    override val apiId: ApiId,
     val labels: Map<String, String> = emptyMap(),
     @Json(name = "@type")
-    val protobufType: String? = "type.googleapis.com/bucketeer.event.client.InternalServerErrorMetricsEvent",
+    override val protobufType: String? = "type.googleapis.com/bucketeer.event.client.InternalServerErrorMetricsEvent",
   ) : MetricsEventData()
 
   @JsonClass(generateAdapter = true)
   data class UnknownErrorMetricsEvent(
-    val apiId: ApiId,
+    override val apiId: ApiId,
     val labels: Map<String, String> = emptyMap(),
     @Json(name = "@type")
-    val protobufType: String? = "type.googleapis.com/bucketeer.event.client.UnknownErrorMetricsEvent",
+    override val protobufType: String? = "type.googleapis.com/bucketeer.event.client.UnknownErrorMetricsEvent",
   ) : MetricsEventData()
 }

--- a/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/BKTClientImplTest.kt
+++ b/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/BKTClientImplTest.kt
@@ -527,34 +527,11 @@ class BKTClientImplTest {
       .isEqualTo(listOf(updatedEvaluation1))
 
     var actual = client.componentImpl.dataModule.eventDao.getEvents()
-    // 2 `latency metric` are duplicate because we fetch evaluation too fast and latency is 0, same clock-time
-    // 1 event from the BKTClient internal init()
-    // 1 event from the test code behind
-    // So 1 event is dismissed to prevent duplicate
-    // Finally we will have 3 items
-    assertThat(actual).hasSize(3)
-
-    // We will trying to fetch evaluation with delay to see if still has duplicate here ?
-    server.enqueue(
-      MockResponse()
-        .setResponseCode(200).setBodyDelay(1, TimeUnit.SECONDS)
-        .setBody(
-          moshi.adapter(GetEvaluationsResponse::class.java)
-            .toJson(
-              GetEvaluationsResponse(
-                evaluations = user2Evaluations,
-                userEvaluationsId = "user_evaluations_id_value_updated_one_more_time",
-              ),
-            ),
-        ),
-    )
-
-    client.fetchEvaluations().get()
-    Thread.sleep(100)
-
-    actual = client.componentImpl.dataModule.eventDao.getEvents()
-    // No more duplicate so it should be 5 items
-    assertThat(actual).hasSize(5)
+    // 2 metrics events (latency , size) from the BKTClient internal init()
+    // 2 metrics events (latency , size) from the test code above
+    // Because we filter duplicate
+    // Finally we will have only 2 items
+    assertThat(actual).hasSize(2)
   }
 
   @Test

--- a/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/BKTClientImplTest.kt
+++ b/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/BKTClientImplTest.kt
@@ -528,7 +528,7 @@ class BKTClientImplTest {
 
     var actual = client.componentImpl.dataModule.eventDao.getEvents()
     // 2 `latency metric` are duplicate because we fetch evaluation too fast and latency is 0, same clock-time
-    // 1 event from init the BKTClient internal init()
+    // 1 event from the BKTClient internal init()
     // 1 event from the test code behind
     // So 1 event is dismissed to prevent duplicate
     // Finally we will have 3 items

--- a/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/BKTClientImplTest.kt
+++ b/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/BKTClientImplTest.kt
@@ -22,7 +22,6 @@ import io.bucketeer.sdk.android.internal.user.toBKTUser
 import io.bucketeer.sdk.android.mocks.evaluation1
 import io.bucketeer.sdk.android.mocks.user1
 import io.bucketeer.sdk.android.mocks.user1Evaluations
-import io.bucketeer.sdk.android.mocks.user2Evaluations
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After

--- a/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/BKTClientImplTest.kt
+++ b/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/BKTClientImplTest.kt
@@ -525,12 +525,11 @@ class BKTClientImplTest {
     assertThat(client.componentImpl.dataModule.evaluationDao.get(user1.id))
       .isEqualTo(listOf(updatedEvaluation1))
 
-    var actual = client.componentImpl.dataModule.eventDao.getEvents()
     // 2 metrics events (latency , size) from the BKTClient internal init()
     // 2 metrics events (latency , size) from the test code above
     // Because we filter duplicate
     // Finally we will have only 2 items
-    assertThat(actual).hasSize(2)
+    assertThat(client.componentImpl.dataModule.eventDao.getEvents()).hasSize(2)
   }
 
   @Test

--- a/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/internal/event/EventInteractorTest.kt
+++ b/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/internal/event/EventInteractorTest.kt
@@ -32,6 +32,7 @@ import io.bucketeer.sdk.android.internal.model.response.RegisterEventsResponse
 import io.bucketeer.sdk.android.internal.remote.ApiClient
 import io.bucketeer.sdk.android.internal.remote.ApiClientImpl
 import io.bucketeer.sdk.android.mocks.evaluation1
+import io.bucketeer.sdk.android.mocks.goalEvent1
 import io.bucketeer.sdk.android.mocks.internalErrorMetricsEvent1
 import io.bucketeer.sdk.android.mocks.latencyMetricsEvent1
 import io.bucketeer.sdk.android.mocks.sizeMetricsEvent1
@@ -901,6 +902,14 @@ class EventInteractorTest {
     interactor.addMetricEvents(listOf(latencyMetricsEvent1, sizeMetricsEvent1))
     // Simulate tracking error metrics
     interactor.addMetricEvents(listOf(internalErrorMetricsEvent1))
+
+    // `addMetricEvents` will only handle only `MetricEvents`
+    // calling it with invalid event_type , it will does nothing
+    // as it is internal method
+    // and only get call from 2 methods `trackFetchEvaluationsSuccess` && `trackApiFailureMetricsEvent`
+    // this case for make sure we didn't make any bug affecting other event type
+    interactor.addMetricEvents(listOf(goalEvent1))
+
     storedEvents = component.dataModule.eventDao.getEvents()
     assertThat(storedEvents).hasSize(3)
     assertThat(storedEvents).containsExactlyElementsIn(expectedStoredEvents)

--- a/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/internal/event/EventInteractorTest.kt
+++ b/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/internal/event/EventInteractorTest.kt
@@ -32,6 +32,9 @@ import io.bucketeer.sdk.android.internal.model.response.RegisterEventsResponse
 import io.bucketeer.sdk.android.internal.remote.ApiClient
 import io.bucketeer.sdk.android.internal.remote.ApiClientImpl
 import io.bucketeer.sdk.android.mocks.evaluation1
+import io.bucketeer.sdk.android.mocks.internalErrorMetricsEvent1
+import io.bucketeer.sdk.android.mocks.latencyMetricsEvent1
+import io.bucketeer.sdk.android.mocks.sizeMetricsEvent1
 import io.bucketeer.sdk.android.mocks.user1
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
@@ -860,6 +863,47 @@ class EventInteractorTest {
         ),
       ),
     )
+  }
+
+  // https://github.com/bucketeer-io/android-client-sdk/pull/68#discussion_r1223850982
+  fun `trackMetricsEvents - prevent duplicate`() {
+    // Simulate tracking metrics events
+    interactor.addMetricEvents(listOf(latencyMetricsEvent1, sizeMetricsEvent1))
+    interactor.addMetricEvents(listOf(internalErrorMetricsEvent1))
+
+    var storedEvents = component.dataModule.eventDao.getEvents()
+    var expectedStoredEvents = listOf(latencyMetricsEvent1, sizeMetricsEvent1, internalErrorMetricsEvent1)
+
+    assertThat(storedEvents).hasSize(3)
+    assertThat(storedEvents).containsExactlyElementsIn(expectedStoredEvents)
+
+    // Simulate tracking duplicate events
+    // (difference `id` but the same `ApiID` and `protobufType`)
+    interactor.addMetricEvents(
+      listOf(
+        latencyMetricsEvent1.copy(id = "4be4-a613-759441a37802"),
+        sizeMetricsEvent1.copy(id = "367d-4be4-759441a3780"),
+      ),
+    )
+    interactor.addMetricEvents(listOf(internalErrorMetricsEvent1.copy(id = "4be4-a613-759441a37802-a613")))
+
+    storedEvents = component.dataModule.eventDao.getEvents()
+    // Check if we haven't any duplicate events
+    assertThat(storedEvents).hasSize(3)
+    assertThat(storedEvents).containsExactlyElementsIn(expectedStoredEvents)
+
+    // Simulate send event success by removing all data from the cache database
+    component.dataModule.eventDao.delete(expectedStoredEvents.map { it.id })
+    storedEvents = component.dataModule.eventDao.getEvents()
+    assertThat(storedEvents).hasSize(0)
+
+    // Simulate tracking metrics events again to see we could add duplicate events from now
+    interactor.addMetricEvents(listOf(latencyMetricsEvent1, sizeMetricsEvent1))
+    // Simulate tracking error metrics
+    interactor.addMetricEvents(listOf(internalErrorMetricsEvent1))
+    storedEvents = component.dataModule.eventDao.getEvents()
+    assertThat(storedEvents).hasSize(3)
+    assertThat(storedEvents).containsExactlyElementsIn(expectedStoredEvents)
   }
 }
 

--- a/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/internal/event/MetricEventsUniqueKeyTest.kt
+++ b/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/internal/event/MetricEventsUniqueKeyTest.kt
@@ -3,8 +3,7 @@ package io.bucketeer.sdk.android.internal.event
 import com.google.common.truth.Truth
 import com.google.testing.junit.testparameterinjector.TestParameter
 import com.google.testing.junit.testparameterinjector.TestParameterInjector
-import io.bucketeer.sdk.android.internal.model.Event
-import io.bucketeer.sdk.android.internal.model.metricsEventUniqueKey
+import io.bucketeer.sdk.android.internal.model.EventData
 import io.bucketeer.sdk.android.mocks.internalErrorMetricsEvent1
 import io.bucketeer.sdk.android.mocks.metricsEvent1
 import io.bucketeer.sdk.android.mocks.sizeMetricsEvent1
@@ -16,17 +15,26 @@ class MetricEventsUniqueKeyTest {
 
   @Suppress("unused")
   enum class ErrorTestCase(
-    val input: Event,
+    val input: EventData.MetricsEvent,
     val expected: String,
   ) {
-    ResponseLatency( metricsEvent1, "GET_EVALUATIONS::type.googleapis.com/bucketeer.event.client.LatencyMetricsEvent"),
-    ResponseSize(sizeMetricsEvent1, "GET_EVALUATIONS::type.googleapis.com/bucketeer.event.client.SizeMetricsEvent"),
-    InternalError(internalErrorMetricsEvent1, "GET_EVALUATIONS::type.googleapis.com/bucketeer.event.client.InternalServerErrorMetricsEvent"),
+    ResponseLatency(
+      metricsEvent1.event as EventData.MetricsEvent,
+      "GET_EVALUATIONS::type.googleapis.com/bucketeer.event.client.LatencyMetricsEvent",
+    ),
+    ResponseSize(
+      sizeMetricsEvent1.event as EventData.MetricsEvent,
+      "GET_EVALUATIONS::type.googleapis.com/bucketeer.event.client.SizeMetricsEvent",
+    ),
+    InternalError(
+      internalErrorMetricsEvent1.event as EventData.MetricsEvent,
+      "GET_EVALUATIONS::type.googleapis.com/bucketeer.event.client.InternalServerErrorMetricsEvent",
+    ),
   }
 
   @Test
   fun toMetricEventType(@TestParameter case: ErrorTestCase) {
-    val result = case.input.metricsEventUniqueKey()
+    val result = case.input.uniqueKey()
     Truth.assertThat(result).isEqualTo(case.expected)
   }
 }

--- a/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/internal/event/MetricEventsUniqueKeyTest.kt
+++ b/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/internal/event/MetricEventsUniqueKeyTest.kt
@@ -5,7 +5,7 @@ import com.google.testing.junit.testparameterinjector.TestParameter
 import com.google.testing.junit.testparameterinjector.TestParameterInjector
 import io.bucketeer.sdk.android.internal.model.EventData
 import io.bucketeer.sdk.android.mocks.internalErrorMetricsEvent1
-import io.bucketeer.sdk.android.mocks.metricsEvent1
+import io.bucketeer.sdk.android.mocks.latencyMetricsEvent1
 import io.bucketeer.sdk.android.mocks.sizeMetricsEvent1
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -19,7 +19,7 @@ class MetricEventsUniqueKeyTest {
     val expected: String,
   ) {
     ResponseLatency(
-      metricsEvent1.event as EventData.MetricsEvent,
+      latencyMetricsEvent1.event as EventData.MetricsEvent,
       "GET_EVALUATIONS::type.googleapis.com/bucketeer.event.client.LatencyMetricsEvent",
     ),
     ResponseSize(

--- a/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/internal/event/MetricEventsUniqueKeyTest.kt
+++ b/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/internal/event/MetricEventsUniqueKeyTest.kt
@@ -1,0 +1,32 @@
+package io.bucketeer.sdk.android.internal.event
+
+import com.google.common.truth.Truth
+import com.google.testing.junit.testparameterinjector.TestParameter
+import com.google.testing.junit.testparameterinjector.TestParameterInjector
+import io.bucketeer.sdk.android.internal.model.Event
+import io.bucketeer.sdk.android.internal.model.metricsEventUniqueKey
+import io.bucketeer.sdk.android.mocks.internalErrorMetricsEvent1
+import io.bucketeer.sdk.android.mocks.metricsEvent1
+import io.bucketeer.sdk.android.mocks.sizeMetricsEvent1
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(TestParameterInjector::class)
+class MetricEventsUniqueKeyTest {
+
+  @Suppress("unused")
+  enum class ErrorTestCase(
+    val input: Event,
+    val expected: String,
+  ) {
+    ResponseLatency( metricsEvent1, "GET_EVALUATIONS::type.googleapis.com/bucketeer.event.client.LatencyMetricsEvent"),
+    ResponseSize(sizeMetricsEvent1, "GET_EVALUATIONS::type.googleapis.com/bucketeer.event.client.SizeMetricsEvent"),
+    InternalError(internalErrorMetricsEvent1, "GET_EVALUATIONS::type.googleapis.com/bucketeer.event.client.InternalServerErrorMetricsEvent"),
+  }
+
+  @Test
+  fun toMetricEventType(@TestParameter case: ErrorTestCase) {
+    val result = case.input.metricsEventUniqueKey()
+    Truth.assertThat(result).isEqualTo(case.expected)
+  }
+}

--- a/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/internal/event/db/EventDaoImplTest.kt
+++ b/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/internal/event/db/EventDaoImplTest.kt
@@ -9,6 +9,7 @@ import io.bucketeer.sdk.android.internal.di.DataModule
 import io.bucketeer.sdk.android.mocks.evaluationEvent1
 import io.bucketeer.sdk.android.mocks.evaluationEvent2
 import io.bucketeer.sdk.android.mocks.goalEvent1
+import io.bucketeer.sdk.android.mocks.goalEvent2
 import io.bucketeer.sdk.android.mocks.metricsEvent1
 import org.junit.After
 import org.junit.Before
@@ -69,7 +70,7 @@ class EventDaoImplTest {
   fun addEvents() {
     dao.addEvents(listOf(evaluationEvent1, goalEvent1, metricsEvent1, evaluationEvent2))
 
-    val actual = dao.getEvents()
+    var actual = dao.getEvents()
 
     assertThat(actual).hasSize(4)
     assertThat(actual).containsExactly(
@@ -77,6 +78,31 @@ class EventDaoImplTest {
       goalEvent1,
       metricsEvent1,
       evaluationEvent2,
+    )
+
+    // Try adding duplicate events
+    dao.addEvents(listOf(evaluationEvent1, goalEvent1, metricsEvent1, evaluationEvent2))
+    actual = dao.getEvents()
+    // Check if we have duplicate
+    assertThat(actual).hasSize(4)
+    assertThat(actual).containsExactly(
+      evaluationEvent1,
+      goalEvent1,
+      metricsEvent1,
+      evaluationEvent2,
+    )
+
+    // Add new event
+    dao.addEvents(listOf(evaluationEvent2, goalEvent2))
+    actual = dao.getEvents()
+    // Check if we have one more new event
+    assertThat(actual).hasSize(5)
+    assertThat(actual).containsExactly(
+      evaluationEvent1,
+      goalEvent1,
+      metricsEvent1,
+      evaluationEvent2,
+      goalEvent2,
     )
   }
 
@@ -103,11 +129,17 @@ class EventDaoImplTest {
 
     dao.delete(ids)
 
-    val actual = dao.getEvents()
+    var actual = dao.getEvents()
 
     assertThat(actual).hasSize(2)
 
     assertThat(actual[0]).isEqualTo(goalEvent1)
     assertThat(actual[1]).isEqualTo(evaluationEvent2)
+
+    // After events are synced and deleted, we should able to add it again,
+    // It will not count as duplicate because there will be an interval between event logging times.
+    dao.addEvents(target)
+    actual = dao.getEvents()
+    assertThat(actual).hasSize(4)
   }
 }

--- a/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/internal/event/db/EventDaoImplTest.kt
+++ b/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/internal/event/db/EventDaoImplTest.kt
@@ -101,8 +101,8 @@ class EventDaoImplTest {
       duplicateGoalEvent1,
     )
 
-    //Simulator `register_event` success and synced event will be delete from database
-    dao.delete(listOf(evaluationEvent1, goalEvent1, metricsEvent1, evaluationEvent2,).map { it.id })
+    // Simulator `register_event` success and synced event will be delete from database
+    dao.delete(listOf(evaluationEvent1, goalEvent1, metricsEvent1, evaluationEvent2).map { it.id })
 
     // Add new event
     dao.addEvents(listOf(evaluationEvent2, goalEvent2, duplicateMetricsEvent1))

--- a/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/internal/remote/ApiClientImplTest.kt
+++ b/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/internal/remote/ApiClientImplTest.kt
@@ -14,7 +14,7 @@ import io.bucketeer.sdk.android.internal.model.response.GetEvaluationsResponse
 import io.bucketeer.sdk.android.internal.model.response.RegisterEventsErrorResponse
 import io.bucketeer.sdk.android.internal.model.response.RegisterEventsResponse
 import io.bucketeer.sdk.android.mocks.evaluationEvent1
-import io.bucketeer.sdk.android.mocks.metricsEvent1
+import io.bucketeer.sdk.android.mocks.latencyMetricsEvent1
 import io.bucketeer.sdk.android.mocks.user1
 import io.bucketeer.sdk.android.mocks.user1Evaluations
 import okhttp3.mockwebserver.MockResponse
@@ -277,7 +277,7 @@ internal class ApiClientImplTest {
       moshi = moshi,
     )
 
-    val result = client.registerEvents(events = listOf(evaluationEvent1, metricsEvent1))
+    val result = client.registerEvents(events = listOf(evaluationEvent1, latencyMetricsEvent1))
 
     // assert request
     val request = server.takeRequest()
@@ -287,7 +287,7 @@ internal class ApiClientImplTest {
     assertThat(
       moshi.adapter(RegisterEventsRequest::class.java)
         .fromJson(request.body.readString(Charsets.UTF_8)),
-    ).isEqualTo(RegisterEventsRequest(events = listOf(evaluationEvent1, metricsEvent1)))
+    ).isEqualTo(RegisterEventsRequest(events = listOf(evaluationEvent1, latencyMetricsEvent1)))
 
     // assert response
     assertThat(result).isInstanceOf(RegisterEventsResult.Success::class.java)
@@ -315,7 +315,7 @@ internal class ApiClientImplTest {
     )
 
     val (millis, result) = measureTimeMillisWithResult {
-      client.registerEvents(events = listOf(evaluationEvent1, metricsEvent1))
+      client.registerEvents(events = listOf(evaluationEvent1, latencyMetricsEvent1))
     }
 
     assertThat(millis).isGreaterThan(1_000)
@@ -336,7 +336,7 @@ internal class ApiClientImplTest {
       moshi = moshi,
     )
 
-    val result = client.registerEvents(events = listOf(evaluationEvent1, metricsEvent1))
+    val result = client.registerEvents(events = listOf(evaluationEvent1, latencyMetricsEvent1))
 
     assertThat(result).isInstanceOf(RegisterEventsResult.Failure::class.java)
     val failure = result as RegisterEventsResult.Failure
@@ -368,7 +368,7 @@ internal class ApiClientImplTest {
       moshi = moshi,
     )
 
-    val result = client.registerEvents(events = listOf(evaluationEvent1, metricsEvent1))
+    val result = client.registerEvents(events = listOf(evaluationEvent1, latencyMetricsEvent1))
 
     assertThat(result).isInstanceOf(RegisterEventsResult.Failure::class.java)
     val failure = result as RegisterEventsResult.Failure
@@ -392,7 +392,7 @@ internal class ApiClientImplTest {
       moshi = moshi,
     )
 
-    val result = client.registerEvents(events = listOf(evaluationEvent1, metricsEvent1))
+    val result = client.registerEvents(events = listOf(evaluationEvent1, latencyMetricsEvent1))
 
     assertThat(result).isInstanceOf(RegisterEventsResult.Failure::class.java)
     val failure = result as RegisterEventsResult.Failure

--- a/mocks/src/main/kotlin/io/bucketeer/sdk/android/mocks/events.kt
+++ b/mocks/src/main/kotlin/io/bucketeer/sdk/android/mocks/events.kt
@@ -95,7 +95,6 @@ val duplicateGoalEvent1: Event by lazy {
   )
 }
 
-
 val goalEvent2: Event by lazy {
   Event(
     id = "5ea231b4-c3c7-4b9f-97a2-ee50337f51f0",
@@ -142,7 +141,7 @@ val getEvaluationLatencyMetricsEvent1 = MetricsEventData.LatencyMetricsEvent(
   latencySecond = 2000.0,
 )
 
-//Will duplicate with `metricsEvent1`
+// Will duplicate with `metricsEvent1`
 val duplicateMetricsEvent1: Event by lazy {
   Event(
     id = "bbc03cae-367d-4be4-a613-759441a378aa",

--- a/mocks/src/main/kotlin/io/bucketeer/sdk/android/mocks/events.kt
+++ b/mocks/src/main/kotlin/io/bucketeer/sdk/android/mocks/events.kt
@@ -73,6 +73,29 @@ val goalEvent1: Event by lazy {
   )
 }
 
+val duplicateGoalEvent1: Event by lazy {
+  Event(
+    id = "408741bd-ae4c-45e9-888d-a85e88817fdd",
+    type = EventType.GOAL,
+    event = EventData.GoalEvent(
+      timestamp = 1661780821,
+      goalId = "goal1",
+      userId = user1.id,
+      user = user1,
+      value = 0.0,
+      tag = "",
+      sourceId = SourceID.ANDROID,
+      sdkVersion = io.bucketeer.sdk.android.BuildConfig.SDK_VERSION,
+      metadata = mapOf(
+        "app_version" to "1.2.3",
+        "os_version" to "os_version_value",
+        "device_model" to "device_model_value",
+      ),
+    ),
+  )
+}
+
+
 val goalEvent2: Event by lazy {
   Event(
     id = "5ea231b4-c3c7-4b9f-97a2-ee50337f51f0",
@@ -117,4 +140,46 @@ val getEvaluationLatencyMetricsEvent1 = MetricsEventData.LatencyMetricsEvent(
   ApiId.GET_EVALUATIONS,
   labels = mapOf("tag" to "android", "state" to "FULL"),
   latencySecond = 2000.0,
+)
+
+//Will duplicate with `metricsEvent1`
+val duplicateMetricsEvent1: Event by lazy {
+  Event(
+    id = "bbc03cae-367d-4be4-a613-759441a378aa",
+    type = EventType.METRICS,
+    event = EventData.MetricsEvent(
+      timestamp = 1661823274, // 2022-08-30 01:34:34
+      event = getEvaluationLatencyMetricsEvent1,
+      type = MetricsEventType.GET_EVALUATION_LATENCY,
+      sdkVersion = io.bucketeer.sdk.android.BuildConfig.SDK_VERSION,
+      metadata = mapOf(
+        "app_version" to "1.2.3",
+        "os_version" to "os_version_value",
+        "device_model" to "device_model_value",
+      ),
+    ),
+  )
+}
+
+val sizeMetricsEvent1: Event by lazy {
+  Event(
+    id = "aac03cae-367d-4be4-a613-759441a37820",
+    type = EventType.METRICS,
+    event = EventData.MetricsEvent(
+      timestamp = 1661823275,
+      event = getEvaluationSizeMetricsEvent1,
+      type = MetricsEventType.GET_EVALUATION_SIZE,
+      sdkVersion = io.bucketeer.sdk.android.BuildConfig.SDK_VERSION,
+      metadata = mapOf(
+        "app_version" to "1.2.3",
+        "os_version" to "os_version_value",
+        "device_model" to "device_model_value",
+      ),
+    ),
+  )
+}
+
+val getEvaluationSizeMetricsEvent1 = MetricsEventData.GetEvaluationSizeMetricsEvent(
+  labels = mapOf("tag" to "android", "state" to "FULL"),
+  sizeByte = 400,
 )

--- a/mocks/src/main/kotlin/io/bucketeer/sdk/android/mocks/events.kt
+++ b/mocks/src/main/kotlin/io/bucketeer/sdk/android/mocks/events.kt
@@ -149,7 +149,7 @@ val duplicateMetricsEvent1: Event by lazy {
     event = EventData.MetricsEvent(
       timestamp = 1661823274, // 2022-08-30 01:34:34
       event = getEvaluationLatencyMetricsEvent1,
-      type = MetricsEventType.GET_EVALUATION_LATENCY,
+      type = MetricsEventType.RESPONSE_LATENCY,
       sdkVersion = io.bucketeer.sdk.android.BuildConfig.SDK_VERSION,
       metadata = mapOf(
         "app_version" to "1.2.3",
@@ -167,7 +167,7 @@ val sizeMetricsEvent1: Event by lazy {
     event = EventData.MetricsEvent(
       timestamp = 1661823275,
       event = getEvaluationSizeMetricsEvent1,
-      type = MetricsEventType.GET_EVALUATION_SIZE,
+      type = MetricsEventType.RESPONSE_SIZE,
       sdkVersion = io.bucketeer.sdk.android.BuildConfig.SDK_VERSION,
       metadata = mapOf(
         "app_version" to "1.2.3",
@@ -178,7 +178,30 @@ val sizeMetricsEvent1: Event by lazy {
   )
 }
 
-val getEvaluationSizeMetricsEvent1 = MetricsEventData.GetEvaluationSizeMetricsEvent(
+val getEvaluationSizeMetricsEvent1 = MetricsEventData.SizeMetricsEvent(
+  ApiId.GET_EVALUATIONS,
   labels = mapOf("tag" to "android", "state" to "FULL"),
   sizeByte = 400,
 )
+
+
+val internalErrorMetricsEvent1: Event by lazy {
+  Event(
+    id = "aac03cae-367d-4be4-a613-759441a37820",
+    type = EventType.METRICS,
+    event = EventData.MetricsEvent(
+      timestamp = 1661823275,
+      event = MetricsEventData.InternalServerErrorMetricsEvent(
+        ApiId.GET_EVALUATIONS,
+        labels = mapOf("tag" to "android", "state" to "FULL"),
+      ),
+      type = MetricsEventType.INTERNAL_SERVER_ERROR,
+      sdkVersion = io.bucketeer.sdk.android.BuildConfig.SDK_VERSION,
+      metadata = mapOf(
+        "app_version" to "1.2.3",
+        "os_version" to "os_version_value",
+        "device_model" to "device_model_value",
+      ),
+    ),
+  )
+}

--- a/mocks/src/main/kotlin/io/bucketeer/sdk/android/mocks/events.kt
+++ b/mocks/src/main/kotlin/io/bucketeer/sdk/android/mocks/events.kt
@@ -117,7 +117,7 @@ val goalEvent2: Event by lazy {
   )
 }
 
-val metricsEvent1: Event by lazy {
+val latencyMetricsEvent1: Event by lazy {
   Event(
     id = "e1c03cae-367d-4be4-a613-759441a37801",
     type = EventType.METRICS,
@@ -142,7 +142,7 @@ val getEvaluationLatencyMetricsEvent1 = MetricsEventData.LatencyMetricsEvent(
 )
 
 // Will duplicate with `metricsEvent1`
-val duplicateMetricsEvent1: Event by lazy {
+val duplicateLatencyMetricsEvent1: Event by lazy {
   Event(
     id = "bbc03cae-367d-4be4-a613-759441a378aa",
     type = EventType.METRICS,

--- a/mocks/src/main/kotlin/io/bucketeer/sdk/android/mocks/events.kt
+++ b/mocks/src/main/kotlin/io/bucketeer/sdk/android/mocks/events.kt
@@ -184,7 +184,6 @@ val getEvaluationSizeMetricsEvent1 = MetricsEventData.SizeMetricsEvent(
   sizeByte = 400,
 )
 
-
 val internalErrorMetricsEvent1: Event by lazy {
   Event(
     id = "aac03cae-367d-4be4-a613-759441a37820",


### PR DESCRIPTION
close #67 

# Changes 
- [x] Using `ApiId` and `protobufType` for preventing add duplicate metrics event data to the cache database 
- [x] Update test cases  