### PR TITLE
fix: json data expection while converting reason type

### DIFF
--- a/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/database/DBOpenHelper.kt
+++ b/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/database/DBOpenHelper.kt
@@ -1,48 +1,61 @@
 package io.bucketeer.sdk.android.internal.database
 
 import android.content.Context
+import android.content.SharedPreferences
+import androidx.annotation.VisibleForTesting
 import androidx.sqlite.db.SupportSQLiteDatabase
 import androidx.sqlite.db.SupportSQLiteOpenHelper
 import androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory
 import io.bucketeer.sdk.android.internal.database.migration.Migration1to2
+import io.bucketeer.sdk.android.internal.database.migration.Migration2to3
 import io.bucketeer.sdk.android.internal.evaluation.db.EvaluationEntity
 import io.bucketeer.sdk.android.internal.event.EventEntity
 
-class OpenHelperCallback : SupportSQLiteOpenHelper.Callback(VERSION) {
+class OpenHelperCallback(
+  private val sharedPreferences: SharedPreferences
+) : SupportSQLiteOpenHelper.Callback(VERSION) {
 
   companion object {
     const val FILE_NAME = "bucketeer.db"
-    const val VERSION = 2
+    const val VERSION = 3
+
+    @VisibleForTesting
+    fun v2Schema(db: SupportSQLiteDatabase) {
+      db.execSQL(
+        """
+        |CREATE TABLE ${EvaluationEntity.TABLE_NAME} (
+        |   ${EvaluationEntity.COLUMN_USER_ID} TEXT,
+        |   ${EvaluationEntity.COLUMN_FEATURE_ID} TEXT,
+        |   ${EvaluationEntity.COLUMN_EVALUATION} TEXT,
+        |   PRIMARY KEY(
+        |     ${EvaluationEntity.COLUMN_USER_ID},
+        |     ${EvaluationEntity.COLUMN_FEATURE_ID}
+        |   )
+        |)
+        """.trimMargin(),
+      )
+
+      db.execSQL(
+        """
+        |CREATE TABLE ${EventEntity.TABLE_NAME} (
+        |   ${EventEntity.COLUMN_ID} TEXT PRIMARY KEY,
+        |   ${EventEntity.COLUMN_EVENT} TEXT
+        |)
+        """.trimMargin(),
+      )
+    }
   }
 
   override fun onCreate(db: SupportSQLiteDatabase) {
-    db.execSQL(
-      """
-      |CREATE TABLE ${EvaluationEntity.TABLE_NAME} (
-      |   ${EvaluationEntity.COLUMN_USER_ID} TEXT,
-      |   ${EvaluationEntity.COLUMN_FEATURE_ID} TEXT,
-      |   ${EvaluationEntity.COLUMN_EVALUATION} TEXT,
-      |   PRIMARY KEY(
-      |     ${EvaluationEntity.COLUMN_USER_ID},
-      |     ${EvaluationEntity.COLUMN_FEATURE_ID}
-      |   )
-      |)
-      """.trimMargin(),
-    )
-
-    db.execSQL(
-      """
-      |CREATE TABLE ${EventEntity.TABLE_NAME} (
-      |   ${EventEntity.COLUMN_ID} TEXT PRIMARY KEY,
-      |   ${EventEntity.COLUMN_EVENT} TEXT
-      |)
-      """.trimMargin(),
-    )
+    v2Schema(db)
   }
 
   override fun onUpgrade(db: SupportSQLiteDatabase, oldVersion: Int, newVersion: Int) {
     if (oldVersion < 2) {
-      Migration1to2().migrate(db)
+      Migration1to2().migrate(db, sharedPreferences)
+    }
+    if (oldVersion < 3) {
+      Migration2to3().migrate(db, sharedPreferences)
     }
   }
 }
@@ -50,10 +63,11 @@ class OpenHelperCallback : SupportSQLiteOpenHelper.Callback(VERSION) {
 fun createDatabase(
   context: Context,
   fileName: String? = OpenHelperCallback.FILE_NAME,
+  sharedPreferences: SharedPreferences,
 ): SupportSQLiteOpenHelper {
   val config = SupportSQLiteOpenHelper.Configuration.builder(context)
     .name(fileName)
-    .callback(OpenHelperCallback())
+    .callback(OpenHelperCallback(sharedPreferences))
     .build()
 
   return FrameworkSQLiteOpenHelperFactory().create(config)

--- a/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/database/DBOpenHelper.kt
+++ b/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/database/DBOpenHelper.kt
@@ -12,7 +12,7 @@ import io.bucketeer.sdk.android.internal.evaluation.db.EvaluationEntity
 import io.bucketeer.sdk.android.internal.event.EventEntity
 
 class OpenHelperCallback(
-  private val sharedPreferences: SharedPreferences
+  private val sharedPreferences: SharedPreferences,
 ) : SupportSQLiteOpenHelper.Callback(VERSION) {
 
   companion object {

--- a/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/database/migration/Migration.kt
+++ b/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/database/migration/Migration.kt
@@ -1,7 +1,8 @@
 package io.bucketeer.sdk.android.internal.database.migration
 
+import android.content.SharedPreferences
 import androidx.sqlite.db.SupportSQLiteDatabase
 
 interface Migration {
-  fun migrate(db: SupportSQLiteDatabase)
+  fun migrate(db: SupportSQLiteDatabase, sharedPreferences: SharedPreferences)
 }

--- a/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/database/migration/Migration1to2.kt
+++ b/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/database/migration/Migration1to2.kt
@@ -1,10 +1,11 @@
 package io.bucketeer.sdk.android.internal.database.migration
 
+import android.content.SharedPreferences
 import androidx.sqlite.db.SupportSQLiteDatabase
 
 class Migration1to2 : Migration {
 
-  override fun migrate(db: SupportSQLiteDatabase) {
+  override fun migrate(db: SupportSQLiteDatabase, sharedPreferences: SharedPreferences) {
     db.execSQL("DROP TABLE current_evaluation")
     db.execSQL("DROP TABLE latest_evaluation")
     db.execSQL("DROP TABLE event")

--- a/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/database/migration/Migration2to3.kt
+++ b/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/database/migration/Migration2to3.kt
@@ -9,6 +9,9 @@ import io.bucketeer.sdk.android.internal.event.EventEntity
 class Migration2to3 : Migration {
 
   override fun migrate(db: SupportSQLiteDatabase, sharedPreferences: SharedPreferences) {
+    // Due to changes in the API endpoint, we must delete all the data stored in the SQLite because
+    // the data model has changed from snake case to camel case.
+    // Reference: https://github.com/bucketeer-io/android-client-sdk/pull/63
     db.delete(EvaluationEntity.TABLE_NAME, null, null)
     db.delete(EventEntity.TABLE_NAME, null, null)
 

--- a/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/database/migration/Migration2to3.kt
+++ b/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/database/migration/Migration2to3.kt
@@ -1,0 +1,19 @@
+package io.bucketeer.sdk.android.internal.database.migration
+
+import android.content.SharedPreferences
+import androidx.sqlite.db.SupportSQLiteDatabase
+import io.bucketeer.sdk.android.internal.Constants
+import io.bucketeer.sdk.android.internal.evaluation.db.EvaluationEntity
+import io.bucketeer.sdk.android.internal.event.EventEntity
+
+class Migration2to3 : Migration {
+
+  override fun migrate(db: SupportSQLiteDatabase, sharedPreferences: SharedPreferences) {
+    db.delete(EvaluationEntity.TABLE_NAME, null, null)
+    db.delete(EventEntity.TABLE_NAME, null, null)
+
+    // We also must delete the user evaluation id to force the server returns all the evaluations again.
+    // Otherwise, it won't send the evaluations until the user changes the flag on the admin console.
+    sharedPreferences.edit().remove(Constants.PREFERENCE_KEY_USER_EVALUATION_ID).commit()
+  }
+}

--- a/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/di/DataModule.kt
+++ b/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/di/DataModule.kt
@@ -57,6 +57,7 @@ internal open class DataModule(
     createDatabase(
       context = application,
       fileName = if (inMemoryDB) null else OpenHelperCallback.FILE_NAME,
+      sharedPreferences,
     )
   }
 

--- a/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/internal/database/migration/MigrationTest.kt
+++ b/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/internal/database/migration/MigrationTest.kt
@@ -35,7 +35,8 @@ class MigrationTest {
     moshi = DataModule.createMoshi()
     val context: Context = ApplicationProvider.getApplicationContext()
     sharedPreferences = context.getSharedPreferences(
-      Constants.PREFERENCES_NAME, Context.MODE_PRIVATE
+      Constants.PREFERENCES_NAME,
+      Context.MODE_PRIVATE,
     )
   }
 
@@ -106,8 +107,8 @@ class MigrationTest {
     assertThat(evaluationDao.get(user1.id)).isNotEmpty()
     assertThat(eventDao.getEvents()).isNotEmpty()
     assertThat(
-      sharedPreferences.getString(Constants.PREFERENCE_KEY_USER_EVALUATION_ID, ""))
-      .isEqualTo("user-evaluation-id")
+      sharedPreferences.getString(Constants.PREFERENCE_KEY_USER_EVALUATION_ID, ""),
+    ).isEqualTo("user-evaluation-id")
 
     // Migrate
     openHelper.writableDatabase.transaction {

--- a/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/internal/evaluation/db/EvaluationDaoImplTest.kt
+++ b/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/internal/evaluation/db/EvaluationDaoImplTest.kt
@@ -1,10 +1,14 @@
 package io.bucketeer.sdk.android.internal.evaluation.db
 
+import android.content.Context
+import android.content.SharedPreferences
 import android.database.Cursor
 import androidx.sqlite.db.SupportSQLiteOpenHelper
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import com.squareup.moshi.Moshi
+import io.bucketeer.sdk.android.internal.Constants
+import io.bucketeer.sdk.android.internal.database.OpenHelperCallback
 import io.bucketeer.sdk.android.internal.database.createDatabase
 import io.bucketeer.sdk.android.internal.database.getString
 import io.bucketeer.sdk.android.internal.database.select
@@ -27,11 +31,16 @@ class EvaluationDaoImplTest {
   private lateinit var dao: EvaluationDaoImpl
   private lateinit var openHelper: SupportSQLiteOpenHelper
   private lateinit var moshi: Moshi
+  private lateinit var sharedPreferences: SharedPreferences
 
   @Before
   fun setup() {
     moshi = DataModule.createMoshi()
-    openHelper = createDatabase(ApplicationProvider.getApplicationContext())
+    val context: Context = ApplicationProvider.getApplicationContext()
+    sharedPreferences = context.getSharedPreferences(
+      Constants.PREFERENCES_NAME, Context.MODE_PRIVATE
+    )
+    openHelper = createDatabase(context, OpenHelperCallback.FILE_NAME, sharedPreferences)
 
     dao = EvaluationDaoImpl(openHelper, moshi)
   }

--- a/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/internal/evaluation/db/EvaluationDaoImplTest.kt
+++ b/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/internal/evaluation/db/EvaluationDaoImplTest.kt
@@ -38,7 +38,8 @@ class EvaluationDaoImplTest {
     moshi = DataModule.createMoshi()
     val context: Context = ApplicationProvider.getApplicationContext()
     sharedPreferences = context.getSharedPreferences(
-      Constants.PREFERENCES_NAME, Context.MODE_PRIVATE
+      Constants.PREFERENCES_NAME,
+      Context.MODE_PRIVATE,
     )
     openHelper = createDatabase(context, OpenHelperCallback.FILE_NAME, sharedPreferences)
 

--- a/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/internal/event/db/EventDaoImplTest.kt
+++ b/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/internal/event/db/EventDaoImplTest.kt
@@ -1,9 +1,13 @@
 package io.bucketeer.sdk.android.internal.event.db
 
+import android.content.Context
+import android.content.SharedPreferences
 import androidx.sqlite.db.SupportSQLiteOpenHelper
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import com.squareup.moshi.Moshi
+import io.bucketeer.sdk.android.internal.Constants
+import io.bucketeer.sdk.android.internal.database.OpenHelperCallback
 import io.bucketeer.sdk.android.internal.database.createDatabase
 import io.bucketeer.sdk.android.internal.di.DataModule
 import io.bucketeer.sdk.android.mocks.evaluationEvent1
@@ -21,11 +25,16 @@ class EventDaoImplTest {
   private lateinit var dao: EventDaoImpl
   private lateinit var openHelper: SupportSQLiteOpenHelper
   private lateinit var moshi: Moshi
+  private lateinit var sharedPreferences: SharedPreferences
 
   @Before
   fun setup() {
     moshi = DataModule.createMoshi()
-    openHelper = createDatabase(ApplicationProvider.getApplicationContext())
+    val context: Context = ApplicationProvider.getApplicationContext()
+    sharedPreferences = context.getSharedPreferences(
+      Constants.PREFERENCES_NAME, Context.MODE_PRIVATE
+    )
+    openHelper = createDatabase(context, OpenHelperCallback.FILE_NAME, sharedPreferences)
 
     dao = EventDaoImpl(openHelper, moshi)
   }

--- a/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/internal/event/db/EventDaoImplTest.kt
+++ b/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/internal/event/db/EventDaoImplTest.kt
@@ -32,7 +32,8 @@ class EventDaoImplTest {
     moshi = DataModule.createMoshi()
     val context: Context = ApplicationProvider.getApplicationContext()
     sharedPreferences = context.getSharedPreferences(
-      Constants.PREFERENCES_NAME, Context.MODE_PRIVATE
+      Constants.PREFERENCES_NAME,
+      Context.MODE_PRIVATE,
     )
     openHelper = createDatabase(context, OpenHelperCallback.FILE_NAME, sharedPreferences)
 

--- a/mocks/src/main/kotlin/io/bucketeer/sdk/android/mocks/evaluations.kt
+++ b/mocks/src/main/kotlin/io/bucketeer/sdk/android/mocks/evaluations.kt
@@ -88,8 +88,8 @@ val evaluationEvent: Event by lazy {
       tag = "android",
       timestamp = 10,
       sourceId = SourceID.ANDROID,
-      user = User("user-id")
+      user = User("user-id"),
     ),
-    EventType.EVALUATION
+    EventType.EVALUATION,
   )
 }

--- a/mocks/src/main/kotlin/io/bucketeer/sdk/android/mocks/evaluations.kt
+++ b/mocks/src/main/kotlin/io/bucketeer/sdk/android/mocks/evaluations.kt
@@ -3,8 +3,13 @@
 package io.bucketeer.sdk.android.mocks
 
 import io.bucketeer.sdk.android.internal.model.Evaluation
+import io.bucketeer.sdk.android.internal.model.Event
+import io.bucketeer.sdk.android.internal.model.EventData
+import io.bucketeer.sdk.android.internal.model.EventType
 import io.bucketeer.sdk.android.internal.model.Reason
 import io.bucketeer.sdk.android.internal.model.ReasonType
+import io.bucketeer.sdk.android.internal.model.SourceID
+import io.bucketeer.sdk.android.internal.model.User
 import io.bucketeer.sdk.android.internal.model.UserEvaluations
 
 val user1Evaluations: UserEvaluations by lazy {
@@ -66,5 +71,25 @@ val evaluation3: Evaluation by lazy {
     reason = Reason(
       type = ReasonType.DEFAULT,
     ),
+  )
+}
+
+val evaluationEvent: Event by lazy {
+  Event(
+    "event-id",
+    EventData.EvaluationEvent(
+      featureId = "test-feature-3",
+      featureVersion = 9,
+      userId = "user-id",
+      variationId = "test-feature-1-variation-A",
+      reason = Reason(
+        type = ReasonType.DEFAULT,
+      ),
+      tag = "android",
+      timestamp = 10,
+      sourceId = SourceID.ANDROID,
+      user = User("user-id")
+    ),
+    EventType.EVALUATION
   )
 }


### PR DESCRIPTION
Due to changes made in this [PR](https://github.com/bucketeer-io/android-client-sdk/pull/63) in the API response, some users are getting the following error.

```
Caused by: com.squareup.moshi.JsonDataException: Expected a string but was NUMBER at path $.reason.type
``` 

Because the reason object has changed, we must delete the old evaluation data in the evaluation table while upgrading the SDK.
