### PR TITLE
perf: improve the network traffic and response time

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,8 +1,6 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
     <JetCodeStyleSettings>
-      <option name="NAME_COUNT_TO_USE_STAR_IMPORT" value="2147483647" />
-      <option name="NAME_COUNT_TO_USE_STAR_IMPORT_FOR_MEMBERS" value="2147483647" />
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
     </JetCodeStyleSettings>
     <codeStyleSettings language="EditorConfig">

--- a/bucketeer/src/androidTest/kotlin/io/bucketeer/sdk/android/e2e/BKTClientEvaluationUpdateTests.kt
+++ b/bucketeer/src/androidTest/kotlin/io/bucketeer/sdk/android/e2e/BKTClientEvaluationUpdateTests.kt
@@ -1,0 +1,189 @@
+package io.bucketeer.sdk.android.e2e
+
+import android.content.Context
+import androidx.test.annotation.UiThreadTest
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.truth.Truth.assertThat
+import io.bucketeer.sdk.android.BKTClient
+import io.bucketeer.sdk.android.BKTClientImpl
+import io.bucketeer.sdk.android.BKTConfig
+import io.bucketeer.sdk.android.BKTUser
+import io.bucketeer.sdk.android.BuildConfig
+import io.bucketeer.sdk.android.internal.Constants
+import io.bucketeer.sdk.android.internal.database.OpenHelperCallback
+import io.bucketeer.sdk.android.internal.di.ComponentImpl
+import io.bucketeer.sdk.android.internal.model.Evaluation
+import io.bucketeer.sdk.android.internal.model.Reason
+import io.bucketeer.sdk.android.internal.model.ReasonType
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class BKTClientEvaluationUpdateTests {
+  private lateinit var context: Context
+  private lateinit var config: BKTConfig
+  private lateinit var user: BKTUser
+
+  @Before
+  @UiThreadTest
+  fun setup() {
+    context = ApplicationProvider.getApplicationContext()
+  }
+
+  @After
+  @UiThreadTest
+  fun tearDown() {
+    BKTClient.destroy()
+    context.deleteDatabase(OpenHelperCallback.FILE_NAME)
+    context.getSharedPreferences(Constants.PREFERENCES_NAME, Context.MODE_PRIVATE)
+      .edit()
+      .clear()
+      .commit()
+  }
+
+
+  @Test
+  @UiThreadTest
+  // "userEvaluationsId is different and evaluatedAt is too old"
+  fun testUserEvaluationsIdMismatchAndEvaluatedAtTooOld() {
+    config = BKTConfig.builder()
+      .apiKey(BuildConfig.API_KEY)
+      .apiEndpoint(BuildConfig.API_ENDPOINT)
+      .featureTag("Android")
+      .appVersion("1.2.3")
+      .build()
+
+    user = BKTUser.builder()
+      .id(USER_ID)
+      .build()
+
+    val result = BKTClient.initialize(context, config, user).get()
+
+    assertThat(result).isNull()
+    val client = BKTClient.getInstance() as BKTClientImpl
+    val evaluationDao = (client.component as ComponentImpl).dataModule.evaluationDao
+    val evaluationInteractor = client.component.evaluationInteractor
+    val tobeRemoveEvaluation = Evaluation(
+      id = "test-feature-2:9:user id 1",
+      featureId = "test-feature-2",
+      featureVersion = 9,
+      userId = "user id 1",
+      variationId = "test-feature-2-variation-A",
+      variationName = "test variation name2",
+      variationValue = "test variation value2",
+      reason = Reason(
+        type = ReasonType.DEFAULT,
+      ),
+    )
+    evaluationDao.put(USER_ID, listOf(tobeRemoveEvaluation))
+    assert(evaluationDao.get(USER_ID).contains(tobeRemoveEvaluation))
+
+    evaluationInteractor.evaluatedAt = "0"
+    evaluationInteractor.currentEvaluationsId = ""
+    assertThat(evaluationInteractor.currentEvaluationsId).isEmpty()
+    assertThat(evaluationInteractor.evaluatedAt).isEqualTo("0")
+
+    // Prepare for switch tag
+    BKTClient.destroy()
+
+    val configWithNewTag = BKTConfig.builder()
+      .apiKey(BuildConfig.API_KEY)
+      .apiEndpoint(BuildConfig.API_ENDPOINT)
+      .featureTag(FEATURE_TAG)
+      .appVersion("1.2.3")
+      .build()
+
+    val resultWithNewTag = BKTClient.initialize(context, configWithNewTag, user).get()
+
+    assertThat(resultWithNewTag).isNull()
+    val clientWithNewTag = BKTClient.getInstance() as BKTClientImpl
+    val evaluationDaoWithNewTag = (clientWithNewTag.component as ComponentImpl).dataModule.evaluationDao
+    val evaluationInteractorWithNewTag = client.component.evaluationInteractor
+    // Should not contain the previous data
+    assert(evaluationDaoWithNewTag.get(USER_ID).contains(tobeRemoveEvaluation).not())
+    assertThat(evaluationInteractorWithNewTag.currentEvaluationsId).isNotEmpty()
+    assertThat(evaluationInteractorWithNewTag.evaluatedAt).isNotEmpty()
+  }
+
+  @Test
+  @UiThreadTest
+  // userEvaluationId is empty after feature_tag changed
+  fun testInitializeWithNewFeatureTag() {
+    config = BKTConfig.builder()
+      .apiKey(BuildConfig.API_KEY)
+      .apiEndpoint(BuildConfig.API_ENDPOINT)
+      .featureTag("Android_E2E_TEST_2023")
+      .appVersion("1.2.3")
+      .build()
+
+    user = BKTUser.builder()
+      .id(USER_ID)
+      .build()
+
+    val result = BKTClient.initialize(context, config, user).get()
+
+    assertThat(result).isNull()
+    val client = BKTClient.getInstance() as BKTClientImpl
+    val evaluationDao = (client.component as ComponentImpl).dataModule.evaluationDao
+    val tobeRemoveEvaluation = Evaluation(
+      id = "test-feature-2:9:user id 1",
+      featureId = "test-feature-2",
+      featureVersion = 9,
+      userId = "user id 1",
+      variationId = "test-feature-2-variation-A",
+      variationName = "test variation name2",
+      variationValue = "test variation value2",
+      reason = Reason(
+        type = ReasonType.DEFAULT,
+      ),
+    )
+    evaluationDao.put(USER_ID, listOf(tobeRemoveEvaluation))
+    assert(evaluationDao.get(USER_ID).contains(tobeRemoveEvaluation))
+
+    // Prepare for switch tag
+    BKTClient.destroy()
+
+    val configWithNewTag = BKTConfig.builder()
+      .apiKey(BuildConfig.API_KEY)
+      .apiEndpoint(BuildConfig.API_ENDPOINT)
+      .featureTag(FEATURE_TAG)
+      .appVersion("1.2.3")
+      .build()
+
+    val resultWithNewTag = BKTClient.initialize(context, configWithNewTag, user).get()
+
+    assertThat(resultWithNewTag).isNull()
+    val clientWithNewTag = BKTClient.getInstance() as BKTClientImpl
+    val evaluationDaoWithNewTag = (clientWithNewTag.component as ComponentImpl).dataModule.evaluationDao
+    // Should not contain the previous data
+    assert(evaluationDaoWithNewTag.get(USER_ID).contains(tobeRemoveEvaluation).not())
+  }
+
+  @Test
+  @UiThreadTest
+  fun testInitWithoutFeatureTagShouldRetrievesAllFeatures() {
+    config = BKTConfig.builder()
+      .apiKey(BuildConfig.API_KEY)
+      .apiEndpoint(BuildConfig.API_ENDPOINT)
+      .appVersion("1.2.3")
+      .build()
+
+    user = BKTUser.builder()
+      .id(USER_ID)
+      .build()
+
+    val result = BKTClient.initialize(context, config, user).get()
+    assertThat(result).isNull()
+
+    val client = BKTClient.getInstance()
+    val android = client.evaluationDetails("feature-android-e2e-string")
+    assertThat(android).isNotNull()
+    val golang = client.evaluationDetails("feature-go-server-e2e-1")
+    assertThat(golang).isNotNull()
+    val javascript = client.evaluationDetails("feature-js-e2e-string")
+    assertThat(javascript).isNotNull()
+  }
+}

--- a/bucketeer/src/androidTest/kotlin/io/bucketeer/sdk/android/e2e/BKTClientEvaluationUpdateTests.kt
+++ b/bucketeer/src/androidTest/kotlin/io/bucketeer/sdk/android/e2e/BKTClientEvaluationUpdateTests.kt
@@ -44,11 +44,10 @@ class BKTClientEvaluationUpdateTests {
       .commit()
   }
 
-
   @Test
   @UiThreadTest
-  // "userEvaluationsId is different and evaluatedAt is too old"
   fun testUserEvaluationsIdMismatchAndEvaluatedAtTooOld() {
+    // "userEvaluationsId is different and evaluatedAt is too old"
     config = BKTConfig.builder()
       .apiKey(BuildConfig.API_KEY)
       .apiEndpoint(BuildConfig.API_ENDPOINT)
@@ -110,8 +109,8 @@ class BKTClientEvaluationUpdateTests {
 
   @Test
   @UiThreadTest
-  // userEvaluationId is empty after feature_tag changed
   fun testInitializeWithNewFeatureTag() {
+    // userEvaluationId is empty after feature_tag changed
     config = BKTConfig.builder()
       .apiKey(BuildConfig.API_KEY)
       .apiEndpoint(BuildConfig.API_ENDPOINT)

--- a/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/BKTClientImpl.kt
+++ b/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/BKTClientImpl.kt
@@ -81,8 +81,10 @@ internal class BKTClientImpl(
 
   override fun updateUserAttributes(attributes: Map<String, String>) {
     component.userHolder.updateAttributes { attributes }
-    // Force to re-evaluate the user on the server in the next request.
-    component.evaluationInteractor.clearCurrentEvaluationsId()
+    // https://github.com/bucketeer-io/android-client-sdk/issues/69
+    // userAttributesUpdated: when the user attributes change via the customAttributes interface,
+    // the userAttributesUpdated field must be set to true in the next request.
+    component.evaluationInteractor.setUserAttributesUpdated()
   }
 
   override fun fetchEvaluations(timeoutMillis: Long?): Future<BKTException?> {

--- a/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/BKTConfig.kt
+++ b/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/BKTConfig.kt
@@ -87,7 +87,6 @@ data class BKTConfig internal constructor(
     fun build(): BKTConfig {
       require(!this.apiKey.isNullOrEmpty()) { "apiKey is required" }
       require(this.apiEndpoint?.toHttpUrlOrNull() != null) { "apiEndpoint is invalid" }
-      require(!this.featureTag.isNullOrEmpty()) { "featureTag is required" }
       require(!this.appVersion.isNullOrEmpty()) { "appVersion is required" }
 
       if (this.pollingInterval < MINIMUM_POLLING_INTERVAL_MILLIS) {
@@ -108,7 +107,7 @@ data class BKTConfig internal constructor(
       return BKTConfig(
         apiKey = this.apiKey!!,
         apiEndpoint = this.apiEndpoint!!,
-        featureTag = this.featureTag!!,
+        featureTag = this.featureTag ?: "",
         eventsFlushInterval = this.eventsFlushInterval,
         eventsMaxBatchQueueCount = this.eventsMaxQueueSize,
         pollingInterval = this.pollingInterval,

--- a/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/Constants.kt
+++ b/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/Constants.kt
@@ -3,4 +3,7 @@ package io.bucketeer.sdk.android.internal
 internal object Constants {
   const val PREFERENCES_NAME = "bucketeer"
   const val PREFERENCE_KEY_USER_EVALUATION_ID = "user_evaluations_id"
+  const val PREFERENCE_KEY_FEATURE_TAG = "bucketeer_feature_tag"
+  const val PREFERENCE_KEY_EVALUATED_AT = "bucketeer_evaluated_at"
+  const val PREFERENCE_KEY_USER_ATTRIBUTES_UPDATED = "bucketeer_user_attributes_updated"
 }

--- a/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/Constants.kt
+++ b/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/Constants.kt
@@ -3,7 +3,7 @@ package io.bucketeer.sdk.android.internal
 internal object Constants {
   const val PREFERENCES_NAME = "bucketeer"
   const val PREFERENCE_KEY_USER_EVALUATION_ID = "user_evaluations_id"
-  const val PREFERENCE_KEY_FEATURE_TAG = "bucketeer_feature_tag"
-  const val PREFERENCE_KEY_EVALUATED_AT = "bucketeer_evaluated_at"
-  const val PREFERENCE_KEY_USER_ATTRIBUTES_UPDATED = "bucketeer_user_attributes_updated"
+  const val PREFERENCE_KEY_FEATURE_TAG = "feature_tag"
+  const val PREFERENCE_KEY_EVALUATED_AT = "evaluated_at"
+  const val PREFERENCE_KEY_USER_ATTRIBUTES_UPDATED = "user_attributes_updated"
 }

--- a/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/di/Component.kt
+++ b/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/di/Component.kt
@@ -34,6 +34,7 @@ internal class ComponentImpl(
       evaluationDao = dataModule.evaluationDao,
       sharedPreferences = dataModule.sharedPreferences,
       idGenerator = dataModule.idGenerator,
+      featureTag = dataModule.config.featureTag,
     )
   }
 

--- a/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/di/InteractorModule.kt
+++ b/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/di/InteractorModule.kt
@@ -18,6 +18,7 @@ internal class InteractorModule(
     evaluationDao: EvaluationDao,
     sharedPreferences: SharedPreferences,
     idGenerator: IdGenerator,
+    featureTag: String,
   ): EvaluationInteractor {
     return EvaluationInteractor(
       apiClient = apiClient,
@@ -25,6 +26,7 @@ internal class InteractorModule(
       sharedPrefs = sharedPreferences,
       idGenerator = idGenerator,
       mainHandler = mainHandler,
+      featureTag = featureTag,
     )
   }
 

--- a/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/evaluation/EvaluationInteractor.kt
+++ b/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/evaluation/EvaluationInteractor.kt
@@ -67,7 +67,7 @@ internal class EvaluationInteractor(
     get() = sharedPrefs.getString(PREFERENCE_KEY_EVALUATED_AT, "0") ?: "0"
 
     @SuppressLint("ApplySharedPref")
-    private set(value) {
+    set(value) {
       sharedPrefs.edit()
         .putString(PREFERENCE_KEY_EVALUATED_AT, value)
         .commit()

--- a/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/evaluation/EvaluationInteractor.kt
+++ b/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/evaluation/EvaluationInteractor.kt
@@ -154,7 +154,7 @@ internal class EvaluationInteractor(
           shouldNotifyListener = updatedEvaluations.isNotEmpty() || archivedFeatureIds.isNotEmpty()
         }
 
-        // keep only `activeEvaluations` on the database
+        // save `currentEvaluations` to the database
         val success = evaluationDao.deleteAllAndInsert(user.id, currentEvaluations)
         if (!success) {
           loge { "Failed to update latest evaluations" }

--- a/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/evaluation/EvaluationInteractor.kt
+++ b/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/evaluation/EvaluationInteractor.kt
@@ -49,12 +49,12 @@ internal class EvaluationInteractor(
 
   @VisibleForTesting
   internal var featureTag: String
-    get() = sharedPrefs.getString(PREFERENCE_KEY_FEATURE_TAG, "") ?: ""
+    get() = sharedPrefs.getString(Constants.PREFERENCE_KEY_FEATURE_TAG, "") ?: ""
 
     @SuppressLint("ApplySharedPref")
     private set(value) {
       sharedPrefs.edit()
-        .putString(PREFERENCE_KEY_FEATURE_TAG, value)
+        .putString(Constants.PREFERENCE_KEY_FEATURE_TAG, value)
         .commit()
     }
 
@@ -64,23 +64,23 @@ internal class EvaluationInteractor(
   // and it must be saved in the client
   @VisibleForTesting
   internal var evaluatedAt: String
-    get() = sharedPrefs.getString(PREFERENCE_KEY_EVALUATED_AT, "0") ?: "0"
+    get() = sharedPrefs.getString(Constants.PREFERENCE_KEY_EVALUATED_AT, "0") ?: "0"
 
     @SuppressLint("ApplySharedPref")
     set(value) {
       sharedPrefs.edit()
-        .putString(PREFERENCE_KEY_EVALUATED_AT, value)
+        .putString(Constants.PREFERENCE_KEY_EVALUATED_AT, value)
         .commit()
     }
 
   @VisibleForTesting
   internal var userAttributesUpdated: Boolean
-    get() = sharedPrefs.getBoolean(PREFERENCE_KEY_USER_ATTRIBUTES_UPDATED, false)
+    get() = sharedPrefs.getBoolean(Constants.PREFERENCE_KEY_USER_ATTRIBUTES_UPDATED, false)
 
     @SuppressLint("ApplySharedPref")
     private set(value) {
       sharedPrefs.edit()
-        .putBoolean(PREFERENCE_KEY_USER_ATTRIBUTES_UPDATED, value)
+        .putBoolean(Constants.PREFERENCE_KEY_USER_ATTRIBUTES_UPDATED, value)
         .commit()
     }
 
@@ -208,11 +208,5 @@ internal class EvaluationInteractor(
   fun getLatest(userId: String, featureId: String): Evaluation? {
     val evaluations = evaluations[userId] ?: return null
     return evaluations.firstOrNull { it.featureId == featureId }
-  }
-
-  companion object {
-    private const val PREFERENCE_KEY_FEATURE_TAG = "bucketeer_feature_tag"
-    private const val PREFERENCE_KEY_EVALUATED_AT = "bucketeer_evaluated_at"
-    private const val PREFERENCE_KEY_USER_ATTRIBUTES_UPDATED = "bucketeer_user_attributes_updated"
   }
 }

--- a/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/evaluation/EvaluationInteractor.kt
+++ b/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/evaluation/EvaluationInteractor.kt
@@ -39,6 +39,7 @@ internal class EvaluationInteractor(
   @VisibleForTesting
   internal var currentEvaluationsId: String
     get() = sharedPrefs.getString(Constants.PREFERENCE_KEY_USER_EVALUATION_ID, "") ?: ""
+
     @SuppressLint("ApplySharedPref")
     set(value) {
       sharedPrefs.edit()
@@ -48,6 +49,7 @@ internal class EvaluationInteractor(
 
   private var featureTag: String
     get() = sharedPrefs.getString(PREFERENCE_KEY_FEATURE_TAG, "") ?: ""
+
     @SuppressLint("ApplySharedPref")
     private set(value) {
       sharedPrefs.edit()
@@ -60,7 +62,8 @@ internal class EvaluationInteractor(
   // The server will return in the get_evaluations response (UserEvaluations.CreatedAt),
   // and it must be saved in the client
   private var evaluatedAt: String
-    get() = sharedPrefs.getString(PREFERENCE_KEY_EVALUATED_AT, "") ?: ""
+    get() = sharedPrefs.getString(PREFERENCE_KEY_EVALUATED_AT, "0") ?: "0"
+
     @SuppressLint("ApplySharedPref")
     private set(value) {
       sharedPrefs.edit()
@@ -70,6 +73,7 @@ internal class EvaluationInteractor(
 
   private var userAttributesUpdated: Boolean
     get() = sharedPrefs.getBoolean(PREFERENCE_KEY_USER_ATTRIBUTES_UPDATED, false)
+
     @SuppressLint("ApplySharedPref")
     private set(value) {
       sharedPrefs.edit()

--- a/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/evaluation/EvaluationInteractor.kt
+++ b/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/evaluation/EvaluationInteractor.kt
@@ -140,10 +140,12 @@ internal class EvaluationInteractor(
         } else {
           val archivedFeatureIds = response.evaluations.archivedFeatureIds
           val updatedEvaluations = response.evaluations.evaluations
-          val currentEvaluationsMap = evaluationDao.get(user.id).associateBy { it.id }.toMutableMap()
+          // We will use `featureId` to filter the data
+          // Details -> https://github.com/bucketeer-io/android-client-sdk/pull/88/files#r1333847962
+          val currentEvaluationsMap = evaluationDao.get(user.id).associateBy { it.featureId }.toMutableMap()
           // 1- Check the evaluation list in the response and upsert them in the DB if the list is not empty
           updatedEvaluations.forEach { evaluation ->
-            currentEvaluationsMap[evaluation.id] = evaluation
+            currentEvaluationsMap[evaluation.featureId] = evaluation
           }
           // 2- Check the list of the feature flags that were archived on the console and delete them from the DB
           activeEvaluations = currentEvaluationsMap.values.filterNot {

--- a/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/evaluation/EvaluationInteractor.kt
+++ b/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/evaluation/EvaluationInteractor.kt
@@ -47,7 +47,8 @@ internal class EvaluationInteractor(
         .commit()
     }
 
-  private var featureTag: String
+  @VisibleForTesting
+  internal var featureTag: String
     get() = sharedPrefs.getString(PREFERENCE_KEY_FEATURE_TAG, "") ?: ""
 
     @SuppressLint("ApplySharedPref")
@@ -61,7 +62,8 @@ internal class EvaluationInteractor(
   // evaluatedAt: the last time the user was evaluated.
   // The server will return in the get_evaluations response (UserEvaluations.CreatedAt),
   // and it must be saved in the client
-  private var evaluatedAt: String
+  @VisibleForTesting
+  internal var evaluatedAt: String
     get() = sharedPrefs.getString(PREFERENCE_KEY_EVALUATED_AT, "0") ?: "0"
 
     @SuppressLint("ApplySharedPref")
@@ -71,7 +73,8 @@ internal class EvaluationInteractor(
         .commit()
     }
 
-  private var userAttributesUpdated: Boolean
+  @VisibleForTesting
+  internal var userAttributesUpdated: Boolean
     get() = sharedPrefs.getBoolean(PREFERENCE_KEY_USER_ATTRIBUTES_UPDATED, false)
 
     @SuppressLint("ApplySharedPref")

--- a/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/evaluation/EvaluationInteractor.kt
+++ b/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/evaluation/EvaluationInteractor.kt
@@ -127,7 +127,6 @@ internal class EvaluationInteractor(
           return result
         }
 
-        val newEvaluations = response.evaluations.evaluations
         val activeEvaluations: List<Evaluation>
         var shouldNotifyListener = true
 
@@ -137,7 +136,7 @@ internal class EvaluationInteractor(
         val forceUpdate = response.evaluations.forceUpdate
         if (forceUpdate) {
           // 1- Delete all the evaluations from DB, and save the latest evaluations from the response into the DB
-          activeEvaluations = newEvaluations
+          activeEvaluations = response.evaluations.evaluations
         } else {
           val archivedFeatureIds = response.evaluations.archivedFeatureIds
           val updatedEvaluations = response.evaluations.evaluations
@@ -146,8 +145,8 @@ internal class EvaluationInteractor(
           updatedEvaluations.forEach { evaluation ->
             currentEvaluationsMap[evaluation.id] = evaluation
           }
+          // 2- Check the list of the feature flags that were archived on the console and delete them from the DB
           activeEvaluations = currentEvaluationsMap.values.filterNot {
-            // 2- Check the list of the feature flags that were archived on the console and delete them from the DB
             archivedFeatureIds.contains(it.featureId)
           }
           shouldNotifyListener = updatedEvaluations.isNotEmpty() || archivedFeatureIds.isNotEmpty()

--- a/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/evaluation/EvaluationInteractor.kt
+++ b/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/evaluation/EvaluationInteractor.kt
@@ -153,12 +153,13 @@ internal class EvaluationInteractor(
           shouldNotifyListener = updatedEvaluations.isNotEmpty() || archivedFeatureIds.isNotEmpty()
         }
 
+        // keep only `activeEvaluations` on the database
         val success = evaluationDao.deleteAllAndInsert(user.id, activeEvaluations)
         if (!success) {
           loge { "Failed to update latest evaluations" }
           return result
         }
-        // update in-memory cache
+        // put `activeEvaluations` to the in-memory cache
         evaluations[user.id] = activeEvaluations
 
         this.currentEvaluationsId = newEvaluationsId

--- a/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/evaluation/EvaluationInteractor.kt
+++ b/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/evaluation/EvaluationInteractor.kt
@@ -153,7 +153,7 @@ internal class EvaluationInteractor(
           shouldNotifyListener = updatedEvaluations.isNotEmpty() || archivedFeatureIds.isNotEmpty()
         }
 
-        val success = evaluationDao.deleteAllAndInsert(user.id, newEvaluations)
+        val success = evaluationDao.deleteAllAndInsert(user.id, activeEvaluations)
         if (!success) {
           loge { "Failed to update latest evaluations" }
           return result

--- a/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/evaluation/EvaluationInteractor.kt
+++ b/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/evaluation/EvaluationInteractor.kt
@@ -160,7 +160,7 @@ internal class EvaluationInteractor(
           loge { "Failed to update latest evaluations" }
           return result
         }
-        // put `activeEvaluations` to the in-memory cache
+        // directly update the in-memory cache
         evaluations[user.id] = currentEvaluations
 
         this.currentEvaluationsId = newEvaluationsId

--- a/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/evaluation/EvaluationInteractor.kt
+++ b/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/evaluation/EvaluationInteractor.kt
@@ -25,6 +25,7 @@ internal class EvaluationInteractor(
   private val evaluationDao: EvaluationDao,
   private val sharedPrefs: SharedPreferences,
   private val idGenerator: IdGenerator,
+  featureTag: String,
   private val mainHandler: Handler,
 ) {
   // key: userId
@@ -44,6 +45,32 @@ internal class EvaluationInteractor(
         .putString(Constants.PREFERENCE_KEY_USER_EVALUATION_ID, value)
         .commit()
     }
+
+  @VisibleForTesting
+  internal var featureTag: String
+    get() = sharedPrefs.getString(Constants.PREFERENCE_KEY_USER_EVALUATION_ID, "") ?: ""
+
+    @SuppressLint("ApplySharedPref")
+    private set(value) {
+      sharedPrefs.edit()
+        .putString(Constants.PREFERENCE_KEY_USER_EVALUATION_ID, value)
+        .commit()
+    }
+
+  init {
+    updateFeatureTag(featureTag)
+  }
+
+  private fun updateFeatureTag(value: String) {
+    // using `this.featureTag` to make it doesn't confuse with the constructor params `featureTag`
+    // https://github.com/bucketeer-io/android-client-sdk/issues/69
+    // 1- Save the featureTag in the UserDefault configured in the BKTConfig
+    // 2- Clear the userEvaluationsID in the UserDefault if the featureTag changes
+    if (this.featureTag != value) {
+      currentEvaluationsId = ""
+      this.featureTag = value
+    }
+  }
 
   @Suppress("MoveVariableDeclarationIntoWhen")
   fun fetch(user: User, timeoutMillis: Long?): GetEvaluationsResult {

--- a/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/evaluation/EvaluationInteractor.kt
+++ b/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/evaluation/EvaluationInteractor.kt
@@ -91,8 +91,8 @@ internal class EvaluationInteractor(
   private fun updateFeatureTag(value: String) {
     // using `this.featureTag` to make it doesn't confuse with the constructor params `featureTag`
     // https://github.com/bucketeer-io/android-client-sdk/issues/69
-    // 1- Save the featureTag in the UserDefault configured in the BKTConfig
-    // 2- Clear the userEvaluationsID in the UserDefault if the featureTag changes
+    // 1- Save the featureTag in the SharedPreferences configured in the BKTConfig
+    // 2- Clear the userEvaluationsID in the SharedPreferences if the featureTag changes
     if (this.featureTag != value) {
       currentEvaluationsId = ""
       this.featureTag = value

--- a/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/model/UserEvaluations.kt
+++ b/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/model/UserEvaluations.kt
@@ -6,4 +6,7 @@ import com.squareup.moshi.JsonClass
 data class UserEvaluations(
   val id: String,
   val evaluations: List<Evaluation> = emptyList(),
+  val createdAt: String,
+  val forceUpdate: Boolean,
+  val archivedFeatureIds: List<String> = emptyList(),
 )

--- a/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/model/UserEvaluations.kt
+++ b/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/model/UserEvaluations.kt
@@ -5,8 +5,8 @@ import com.squareup.moshi.JsonClass
 @JsonClass(generateAdapter = true)
 data class UserEvaluations(
   val id: String,
-  val evaluations: List<Evaluation> = emptyList(),
   val createdAt: String,
   val forceUpdate: Boolean,
+  val evaluations: List<Evaluation> = emptyList(),
   val archivedFeatureIds: List<String> = emptyList(),
 )

--- a/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/model/request/GetEvaluationsRequest.kt
+++ b/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/model/request/GetEvaluationsRequest.kt
@@ -3,6 +3,7 @@ package io.bucketeer.sdk.android.internal.model.request
 import com.squareup.moshi.JsonClass
 import io.bucketeer.sdk.android.internal.model.SourceID
 import io.bucketeer.sdk.android.internal.model.User
+import io.bucketeer.sdk.android.internal.remote.UserEvaluationCondition
 
 @JsonClass(generateAdapter = true)
 data class GetEvaluationsRequest(
@@ -10,4 +11,5 @@ data class GetEvaluationsRequest(
   val user: User,
   val userEvaluationsId: String,
   val sourceId: SourceID = SourceID.ANDROID,
+  val userEvaluationCondition: UserEvaluationCondition,
 )

--- a/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/remote/ApiClient.kt
+++ b/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/remote/ApiClient.kt
@@ -8,6 +8,7 @@ interface ApiClient {
     user: User,
     userEvaluationsId: String,
     timeoutMillis: Long? = null,
+    condition: UserEvaluationCondition,
   ): GetEvaluationsResult
 
   fun registerEvents(events: List<Event>): RegisterEventsResult

--- a/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/remote/ApiClientImpl.kt
+++ b/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/remote/ApiClientImpl.kt
@@ -46,11 +46,13 @@ internal class ApiClientImpl(
     user: User,
     userEvaluationsId: String,
     timeoutMillis: Long?,
+    condition: UserEvaluationCondition,
   ): GetEvaluationsResult {
     val body = GetEvaluationsRequest(
       tag = featureTag,
       user = user,
       userEvaluationsId = userEvaluationsId,
+      userEvaluationCondition = condition,
     )
 
     val request = Request.Builder()

--- a/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/remote/UserEvaluationCondition.kt
+++ b/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/remote/UserEvaluationCondition.kt
@@ -1,0 +1,8 @@
+package io.bucketeer.sdk.android.internal.remote
+
+import java.util.jar.Attributes
+
+data class UserEvaluationCondition(
+  val evaluatedAt: String,
+  val userAttributesUpdated: String,
+)

--- a/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/remote/UserEvaluationCondition.kt
+++ b/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/remote/UserEvaluationCondition.kt
@@ -1,7 +1,8 @@
 package io.bucketeer.sdk.android.internal.remote
 
-import java.util.jar.Attributes
+import com.squareup.moshi.JsonClass
 
+@JsonClass(generateAdapter = true)
 data class UserEvaluationCondition(
   val evaluatedAt: String,
   val userAttributesUpdated: String,

--- a/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/BKTClientImplTest.kt
+++ b/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/BKTClientImplTest.kt
@@ -477,6 +477,8 @@ class BKTClientImplTest {
                 evaluations = UserEvaluations(
                   id = "id_value",
                   evaluations = listOf(evaluation1),
+                  createdAt = "1690798021",
+                  forceUpdate = true,
                 ),
                 userEvaluationsId = "user_evaluations_id_value",
               ),

--- a/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/BKTClientImplTest.kt
+++ b/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/BKTClientImplTest.kt
@@ -110,7 +110,7 @@ class BKTClientImplTest {
     val lastEvent = dbEvents[1]
     assertSizeMetricsEvent(
       lastEvent,
-      MetricsEventData.SizeMetricsEvent(ApiId.GET_EVALUATIONS, mapOf("tag" to config.featureTag), 645),
+      MetricsEventData.SizeMetricsEvent(ApiId.GET_EVALUATIONS, mapOf("tag" to config.featureTag), 713),
     )
   }
 

--- a/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/BKTConfigTest.kt
+++ b/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/BKTConfigTest.kt
@@ -84,30 +84,27 @@ class BKTConfigTest {
   }
 
   @Test
-  fun `featureTag - unset`() {
-    val error = assertThrows(BKTException.IllegalArgumentException::class.java) {
-      BKTConfig.builder()
-        .apiKey("api-key")
-        .apiEndpoint("https://example.com")
-        .appVersion("1.2.3")
-        .build()
-    }
+  fun `featureTag - optional`() {
+    assertThat(
+      runCatching {
+        BKTConfig.builder()
+          .apiKey("api-key")
+          .apiEndpoint("https://example.com")
+          .appVersion("1.2.3")
+          .build()
+      }.isSuccess,
+    ).isEqualTo(true)
 
-    assertThat(error).hasMessageThat().isEqualTo("featureTag is required")
-  }
-
-  @Test
-  fun `featureTag - empty`() {
-    val error = assertThrows(BKTException.IllegalArgumentException::class.java) {
-      BKTConfig.builder()
-        .apiKey("api-key")
-        .apiEndpoint("https://example.com")
-        .featureTag("")
-        .appVersion("1.2.3")
-        .build()
-    }
-
-    assertThat(error).hasMessageThat().isEqualTo("featureTag is required")
+    assertThat(
+      runCatching {
+        BKTConfig.builder()
+          .apiKey("api-key")
+          .apiEndpoint("https://example.com")
+          .featureTag("")
+          .appVersion("1.2.3")
+          .build()
+      }.isSuccess,
+    ).isEqualTo(true)
   }
 
   @Test

--- a/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/internal/evaluation/EvaluationInteractorTest.kt
+++ b/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/internal/evaluation/EvaluationInteractorTest.kt
@@ -552,45 +552,4 @@ class EvaluationInteractorTest {
 
     assertThat(interactor.updateListeners).isEmpty()
   }
-
-  fun initialDataBeforeTestingConditionUpdate() {
-    // https://github.com/bucketeer-io/android-client-sdk/issues/69
-    // initial response(for preparation)
-    server.enqueue(
-      MockResponse()
-        .setResponseCode(200)
-        .setBody(
-          moshi.adapter(GetEvaluationsResponse::class.java)
-            .toJson(
-              GetEvaluationsResponse(
-                evaluations = user1Evaluations,
-                userEvaluationsId = "user_evaluations_id_value",
-              ),
-            ),
-        ),
-    )
-    val firstResult = interactor.fetch(user1, null)
-    server.takeRequest()
-    assertThat(server.requestCount).isEqualTo(1)
-
-    assertThat(interactor.currentEvaluationsId).isEqualTo("user_evaluations_id_value")
-    assertThat(firstResult).isInstanceOf(GetEvaluationsResult.Success::class.java)
-    val initialEvaluations =
-      (firstResult as GetEvaluationsResult.Success).value.evaluations.evaluations
-    assertThat(initialEvaluations).isEqualTo(
-      listOf(
-        evaluation1,
-        evaluation2,
-      ),
-    )
-    // Check cache
-    assertThat(interactor.evaluations[user1.id]).isEqualTo(
-      listOf(
-        evaluation1,
-        evaluation2,
-      ),
-    )
-
-    shadowOf(Looper.getMainLooper()).idle()
-  }
 }

--- a/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/internal/evaluation/EvaluationInteractorTest.kt
+++ b/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/internal/evaluation/EvaluationInteractorTest.kt
@@ -222,7 +222,6 @@ class EvaluationInteractorTest {
     shadowOf(Looper.getMainLooper()).idle()
   }
 
-
   @Test
   @LooperMode(Mode.PAUSED)
   fun `fetch - initial load`() {
@@ -294,7 +293,7 @@ class EvaluationInteractorTest {
     assertThat(listenerCalled).isTrue()
   }
 
-  //https://github.com/bucketeer-io/android-client-sdk/issues/69
+  // https://github.com/bucketeer-io/android-client-sdk/issues/69
   @Test
   @LooperMode(Mode.PAUSED)
   fun `fetch - force update`() {
@@ -350,7 +349,7 @@ class EvaluationInteractorTest {
     assertThat(listenerCalled).isTrue()
   }
 
-  //https://github.com/bucketeer-io/android-client-sdk/issues/69
+  // https://github.com/bucketeer-io/android-client-sdk/issues/69
   @Test
   @LooperMode(Mode.PAUSED)
   fun `fetch - upsert`() {
@@ -555,7 +554,7 @@ class EvaluationInteractorTest {
   }
 
   fun initialDataBeforeTestingConditionUpdate() {
-    //https://github.com/bucketeer-io/android-client-sdk/issues/69
+    // https://github.com/bucketeer-io/android-client-sdk/issues/69
     // initial response(for preparation)
     server.enqueue(
       MockResponse()

--- a/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/internal/evaluation/EvaluationInteractorTest.kt
+++ b/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/internal/evaluation/EvaluationInteractorTest.kt
@@ -395,7 +395,8 @@ class EvaluationInteractorTest {
       ),
     )
     assertThat(interactor.currentEvaluationsId).isEqualTo("user_evaluations_id_value_updated")
-    // check database should not contain `evaluation1`
+    // check database should not contain `evaluation1` & `evaluation2`
+    // https://github.com/bucketeer-io/android-client-sdk/pull/88/files#r1333847962
     val latestEvaluations = component.dataModule.evaluationDao.get(user1.id)
     assertThat(latestEvaluations).isEqualTo(
       listOf(

--- a/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/internal/evaluation/EvaluationInteractorTest.kt
+++ b/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/internal/evaluation/EvaluationInteractorTest.kt
@@ -281,7 +281,7 @@ class EvaluationInteractorTest {
     val latestEvaluations = component.dataModule.evaluationDao.get(user1.id)
     assertThat(latestEvaluations).isEqualTo(listOf(evaluation1, evaluation2))
 
-    // the featureTag should be `api_key_value`
+    // the featureTag should be `feature_tag_value`
     assertThat(interactor.featureTag).isEqualTo("feature_tag_value")
     // the evaluatedAt should be updated
     assertThat(interactor.evaluatedAt).isEqualTo("1690798021")
@@ -337,7 +337,7 @@ class EvaluationInteractorTest {
     val latestEvaluations = component.dataModule.evaluationDao.get(user1.id)
     assertThat(latestEvaluations).isEqualTo(listOf(evaluation2))
 
-    // the featureTag should be `api_key_value`
+    // the featureTag should be `feature_tag_value`
     assertThat(interactor.featureTag).isEqualTo("feature_tag_value")
     // the evaluatedAt should be updated
     assertThat(interactor.evaluatedAt).isEqualTo("1690798025")
@@ -404,7 +404,7 @@ class EvaluationInteractorTest {
       ),
     )
 
-    // the featureTag should be `api_key_value`
+    // the featureTag should be `feature_tag_value`
     assertThat(interactor.featureTag).isEqualTo("feature_tag_value")
     // the evaluatedAt should be updated
     assertThat(interactor.evaluatedAt).isEqualTo("16907999999")

--- a/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/internal/evaluation/db/EvaluationDaoImplTest.kt
+++ b/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/internal/evaluation/db/EvaluationDaoImplTest.kt
@@ -16,7 +16,7 @@ import io.bucketeer.sdk.android.internal.di.DataModule
 import io.bucketeer.sdk.android.internal.model.Evaluation
 import io.bucketeer.sdk.android.mocks.evaluation1
 import io.bucketeer.sdk.android.mocks.evaluation2
-import io.bucketeer.sdk.android.mocks.evaluation3
+import io.bucketeer.sdk.android.mocks.evaluation4
 import io.bucketeer.sdk.android.mocks.user1
 import io.bucketeer.sdk.android.mocks.user2
 import org.junit.After
@@ -164,7 +164,7 @@ class EvaluationDaoImplTest {
   @Test
   fun `deleteAll - should not update other user's item`() {
     dao.deleteAllAndInsert(user1.id, listOf(evaluation1))
-    dao.deleteAllAndInsert(user2.id, listOf(evaluation3))
+    dao.deleteAllAndInsert(user2.id, listOf(evaluation4))
 
     val actual1 = dao.get(user1.id)
     val actual2 = dao.get(user2.id)
@@ -173,7 +173,7 @@ class EvaluationDaoImplTest {
     assertThat(actual1[0]).isEqualTo(evaluation1)
 
     assertThat(actual2).hasSize(1)
-    assertThat(actual2[0]).isEqualTo(evaluation3)
+    assertThat(actual2[0]).isEqualTo(evaluation4)
   }
 
   private fun getEvaluations(): Cursor {

--- a/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/internal/remote/ApiClientImplTest.kt
+++ b/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/internal/remote/ApiClientImplTest.kt
@@ -116,7 +116,7 @@ internal class ApiClientImplTest {
     val success = result as GetEvaluationsResult.Success
     assertThat(success.value).isEqualTo(expected)
     assertThat(success.seconds).isAtLeast(1)
-    assertThat(success.sizeByte).isEqualTo(638)
+    assertThat(success.sizeByte).isEqualTo(706)
     assertThat(success.featureTag).isEqualTo("feature_tag_value")
   }
 

--- a/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/internal/remote/ApiClientImplTest.kt
+++ b/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/internal/remote/ApiClientImplTest.kt
@@ -84,6 +84,10 @@ internal class ApiClientImplTest {
     val result = client.getEvaluations(
       user = user1,
       userEvaluationsId = "user_evaluation_id",
+      condition = UserEvaluationCondition(
+        evaluatedAt = "1690798100",
+        userAttributesUpdated = "true",
+      ),
     )
 
     // assert request
@@ -100,6 +104,10 @@ internal class ApiClientImplTest {
         user = user1,
         userEvaluationsId = "user_evaluation_id",
         sourceId = SourceID.ANDROID,
+        userEvaluationCondition = UserEvaluationCondition(
+          evaluatedAt = "1690798100",
+          userAttributesUpdated = "true",
+        ),
       ),
     )
 
@@ -126,6 +134,10 @@ internal class ApiClientImplTest {
       client.getEvaluations(
         user = user1,
         userEvaluationsId = "user_evaluation_id",
+        condition = UserEvaluationCondition(
+          evaluatedAt = "1690798200",
+          userAttributesUpdated = "false",
+        ),
       )
     }
 
@@ -153,6 +165,10 @@ internal class ApiClientImplTest {
         user = user1,
         userEvaluationsId = "user_evaluation_id",
         timeoutMillis = TimeUnit.SECONDS.toMillis(1),
+        condition = UserEvaluationCondition(
+          evaluatedAt = "1690798200",
+          userAttributesUpdated = "false",
+        ),
       )
     }
 
@@ -178,6 +194,10 @@ internal class ApiClientImplTest {
     val result = client.getEvaluations(
       user = user1,
       userEvaluationsId = "user_evaluation_id",
+      condition = UserEvaluationCondition(
+        evaluatedAt = "1690798200",
+        userAttributesUpdated = "false",
+      ),
     )
 
     assertThat(result).isInstanceOf(GetEvaluationsResult.Failure::class.java)
@@ -214,6 +234,10 @@ internal class ApiClientImplTest {
     val result = client.getEvaluations(
       user = user1,
       userEvaluationsId = "user_evaluation_id",
+      condition = UserEvaluationCondition(
+        evaluatedAt = "1690799200",
+        userAttributesUpdated = "true",
+      ),
     )
 
     assertThat(result).isInstanceOf(GetEvaluationsResult.Failure::class.java)
@@ -241,6 +265,10 @@ internal class ApiClientImplTest {
     val result = client.getEvaluations(
       user = user1,
       userEvaluationsId = "user_evaluation_id",
+      condition = UserEvaluationCondition(
+        evaluatedAt = "1690799200",
+        userAttributesUpdated = "true",
+      ),
     )
 
     assertThat(result).isInstanceOf(GetEvaluationsResult.Failure::class.java)

--- a/mocks/src/main/kotlin/io/bucketeer/sdk/android/mocks/evaluations.kt
+++ b/mocks/src/main/kotlin/io/bucketeer/sdk/android/mocks/evaluations.kt
@@ -24,7 +24,7 @@ val user1Evaluations: UserEvaluations by lazy {
   )
 }
 
-val user1EvaluationsForeUpdate: UserEvaluations by lazy {
+val user1EvaluationsForceUpdate: UserEvaluations by lazy {
   UserEvaluations(
     id = "17388826713971171773",
     evaluations = listOf(
@@ -40,17 +40,19 @@ val user1EvaluationsUpsert: UserEvaluations by lazy {
     id = "17388826713971171773",
     evaluations = listOf(
       evaluation1,
-      evaluation2,
+      evaluation2ForUpdate,
+      evaluation3,
     ),
-    createdAt = "1690798025",
-    forceUpdate = true,
+    createdAt = "16907999999",
+    forceUpdate = false,
+    archivedFeatureIds = listOf("test-feature-1")
   )
 }
 
 val user2Evaluations: UserEvaluations by lazy {
   UserEvaluations(
     id = "17388826713971171774",
-    evaluations = listOf(evaluation3),
+    evaluations = listOf(evaluation4),
     createdAt = "1690799033",
     forceUpdate = true,
   )
@@ -87,21 +89,29 @@ val evaluation2: Evaluation by lazy {
 }
 
 val evaluation2ForUpdate: Evaluation by lazy {
+  evaluation2.copy(
+    variationId = "test-feature-2-variation-A-updated",
+    variationName = "test variation name2 updated",
+    variationValue = "test variation value2 updated",
+  )
+}
+
+val evaluation3: Evaluation by lazy {
   Evaluation(
-    id = "test-feature-2:9:user id 1",
-    featureId = "test-feature-2",
-    featureVersion = 10,
-    userId = "user id 1",
-    variationId = "test-feature-2-variation-A",
-    variationName = "test variation name2 update",
-    variationValue = "test variation value2 update",
+    id = "test-feature-1:9:user id 3",
+    featureId = "test-feature-3",
+    featureVersion = 9,
+    userId = "user id 2",
+    variationId = "test-feature-1-variation-A",
+    variationName = "test variation name2",
+    variationValue = "test variation value2",
     reason = Reason(
       type = ReasonType.DEFAULT,
     ),
   )
 }
 
-val evaluation3: Evaluation by lazy {
+val evaluation4: Evaluation by lazy {
   Evaluation(
     id = "test-feature-1:9:user id 2",
     featureId = "test-feature-3",

--- a/mocks/src/main/kotlin/io/bucketeer/sdk/android/mocks/evaluations.kt
+++ b/mocks/src/main/kotlin/io/bucketeer/sdk/android/mocks/evaluations.kt
@@ -19,6 +19,8 @@ val user1Evaluations: UserEvaluations by lazy {
       evaluation1,
       evaluation2,
     ),
+    createdAt = "1690798021",
+    forceUpdate = true,
   )
 }
 
@@ -26,6 +28,8 @@ val user2Evaluations: UserEvaluations by lazy {
   UserEvaluations(
     id = "17388826713971171774",
     evaluations = listOf(evaluation3),
+    createdAt = "1690799033",
+    forceUpdate = true,
   )
 }
 

--- a/mocks/src/main/kotlin/io/bucketeer/sdk/android/mocks/evaluations.kt
+++ b/mocks/src/main/kotlin/io/bucketeer/sdk/android/mocks/evaluations.kt
@@ -45,7 +45,7 @@ val user1EvaluationsUpsert: UserEvaluations by lazy {
     ),
     createdAt = "16907999999",
     forceUpdate = false,
-    archivedFeatureIds = listOf("test-feature-1")
+    archivedFeatureIds = listOf("test-feature-1"),
   )
 }
 

--- a/mocks/src/main/kotlin/io/bucketeer/sdk/android/mocks/evaluations.kt
+++ b/mocks/src/main/kotlin/io/bucketeer/sdk/android/mocks/evaluations.kt
@@ -28,7 +28,7 @@ val user1EvaluationsForeUpdate: UserEvaluations by lazy {
   UserEvaluations(
     id = "17388826713971171773",
     evaluations = listOf(
-      evaluation1,
+      evaluation2,
     ),
     createdAt = "1690798025",
     forceUpdate = true,

--- a/mocks/src/main/kotlin/io/bucketeer/sdk/android/mocks/evaluations.kt
+++ b/mocks/src/main/kotlin/io/bucketeer/sdk/android/mocks/evaluations.kt
@@ -24,6 +24,29 @@ val user1Evaluations: UserEvaluations by lazy {
   )
 }
 
+val user1EvaluationsForeUpdate: UserEvaluations by lazy {
+  UserEvaluations(
+    id = "17388826713971171773",
+    evaluations = listOf(
+      evaluation1,
+    ),
+    createdAt = "1690798025",
+    forceUpdate = true,
+  )
+}
+
+val user1EvaluationsUpsert: UserEvaluations by lazy {
+  UserEvaluations(
+    id = "17388826713971171773",
+    evaluations = listOf(
+      evaluation1,
+      evaluation2,
+    ),
+    createdAt = "1690798025",
+    forceUpdate = true,
+  )
+}
+
 val user2Evaluations: UserEvaluations by lazy {
   UserEvaluations(
     id = "17388826713971171774",
@@ -57,6 +80,21 @@ val evaluation2: Evaluation by lazy {
     variationId = "test-feature-2-variation-A",
     variationName = "test variation name2",
     variationValue = "test variation value2",
+    reason = Reason(
+      type = ReasonType.DEFAULT,
+    ),
+  )
+}
+
+val evaluation2ForUpdate: Evaluation by lazy {
+  Evaluation(
+    id = "test-feature-2:9:user id 1",
+    featureId = "test-feature-2",
+    featureVersion = 10,
+    userId = "user id 1",
+    variationId = "test-feature-2-variation-A",
+    variationName = "test variation name2 update",
+    variationValue = "test variation value2 update",
     reason = Reason(
       type = ReasonType.DEFAULT,
     ),

--- a/mocks/src/main/kotlin/io/bucketeer/sdk/android/mocks/evaluations.kt
+++ b/mocks/src/main/kotlin/io/bucketeer/sdk/android/mocks/evaluations.kt
@@ -90,6 +90,10 @@ val evaluation2: Evaluation by lazy {
 
 val evaluation2ForUpdate: Evaluation by lazy {
   evaluation2.copy(
+    // the mock data to cover the bug in the link below
+    // https://github.com/bucketeer-io/android-client-sdk/pull/88/files#r1333847962
+    id = "test-feature-2:10:user id 1",
+    featureVersion = 10,
     variationId = "test-feature-2-variation-A-updated",
     variationName = "test variation name2 updated",
     variationValue = "test variation value2 updated",


### PR DESCRIPTION
Should close #69 
## Changes
#### When the SDK is initialized
- [x] 1- Change the featureTag setting to be optional in the BKTConfig
- [x] 2- Save the featureTag in the SharedPreferences if it is configured in the BKTConfig
- [x] 3- Clear the userEvaluationsID in the SharedPreferences if the featureTag changes

#### Sending requests
- [x] The following new fields will be added to get_evaluations request.

  - [x] evaluatedAt: the last time the user was evaluated. The server will return in the get_evaluations response (UserEvaluations.CreatedAt), and it must be saved in the client
  - [x] userAttributesUpdated: when the user attributes change via the customAttributes interface, the userAttributesUpdated field must be set to true in the next request.
#### Update conditions when getting the response
- The server will return the new following fields in the response.
  - forceUpdate: a boolean that tells the SDK to delete all the current data and save the latest evaluations from the response
  - archivedFeatureIds: a list of feature flag ids that were archived on the console. All those feature flags must be deleted from the DB.


- [x] forceUpdate is True
  - [x] 1- Delete all the evaluations from DB, and save the latest evaluations from the response into the DB
  - [x] 2- Save the UserEvaluations.CreatedAt in the response as evaluatedAt in the SharedPreferences

- [x] forceUpdate is false
  - [x] 1- Check the evaluation list in the response and upsert them in the DB if the list is not empty
  - [x] 2- Check the list of the feature flags that were archived on the console and delete them from the DB
  - [x] 3- Save the UserEvaluations.CreatedAt in the response as evaluatedAt in the SharedPreferences
  
## Testcase
### All current test
- [x] Passed
### Unit tests & Integration tests
#### When the SDK is initialized
- [x] 1- Change the featureTag setting to be optional in the BKTConfig
- [x] 2- Save the featureTag in the SharedPreferences if it is configured in the BKTConfig
- [x] 3- Clear the userEvaluationsID in the SharedPreferences if the featureTag changes

#### Sending requests
- [x] The following new fields will be added to get_evaluations request.

  - [x] evaluatedAt: the last time the user was evaluated. The server will return in the get_evaluations response (UserEvaluations.CreatedAt), and it must be saved in the client
  - [x] userAttributesUpdated: when the user attributes change via the customAttributes interface, the userAttributesUpdated field must be set to true in the next request.
  - [x] userAttributesUpdated need set to `false` after success request
#### Update conditions when getting the response
- The server will return the new following fields in the response.
  - forceUpdate: a boolean that tells the SDK to delete all the current data and save the latest evaluations from the response
  - archivedFeatureIds: a list of feature flag ids that were archived on the console. All those feature flags must be deleted from the DB.

- [x] forceUpdate is True
  - [x] 1- Delete all the evaluations from DB, and save the latest evaluations from the response into the DB
  - [x] 2- Save the UserEvaluations.CreatedAt in the response as evaluatedAt in the SharedPreferences

- [x] forceUpdate is false
  - [x] 1- Check the evaluation list in the response and upsert them in the DB if the list is not empty
  - [x] 2- Check the list of the feature flags that were archived on the console and delete them from the DB
  - [x] 3- Save the UserEvaluations.CreatedAt in the response as evaluatedAt in the SharedPreferences
  
### E2E Test
- [x] force update
- [x] update the current active evaluation and remove archived evaluation
- [x] the client with an empty `feature_tag` will be able to load all evaluations (even for different platform) 