### PR TITLE
fix: latency seconds field in metrics event

### DIFF
--- a/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/event/EventCreators.kt
+++ b/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/event/EventCreators.kt
@@ -111,7 +111,7 @@ internal fun newSuccessMetricsEvents(
   featureTag: String,
   appVersion: String,
   apiId: ApiId,
-  latencySecond: Long,
+  latencySecond: Double,
   sizeByte: Int,
 ): List<Event> {
   val labels = mapOf("tag" to featureTag)
@@ -125,7 +125,7 @@ internal fun newSuccessMetricsEvents(
         event = MetricsEventData.LatencyMetricsEvent(
           apiId = apiId,
           labels = labels,
-          latencySecond = latencySecond.toDouble(),
+          latencySecond = latencySecond,
         ),
         sdkVersion = BuildConfig.SDK_VERSION,
         metadata = newMetadata(appVersion),

--- a/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/event/EventInteractor.kt
+++ b/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/event/EventInteractor.kt
@@ -56,7 +56,7 @@ internal class EventInteractor(
 
   fun trackFetchEvaluationsSuccess(
     featureTag: String,
-    seconds: Long,
+    seconds: Double,
     sizeByte: Int,
   ) {
     // For get_evaluations, we will report all metrics events, Including the latency and size metrics events.

--- a/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/remote/ApiClientImpl.kt
+++ b/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/remote/ApiClientImpl.kt
@@ -94,7 +94,7 @@ internal class ApiClientImpl(
 
       GetEvaluationsResult.Success(
         value = response,
-        seconds = millis.toDouble() / 1000,
+        seconds = millis / 1000.0,
         sizeByte = contentLength,
         featureTag = featureTag,
       )

--- a/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/remote/ApiClientImpl.kt
+++ b/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/remote/ApiClientImpl.kt
@@ -94,7 +94,7 @@ internal class ApiClientImpl(
 
       GetEvaluationsResult.Success(
         value = response,
-        seconds = TimeUnit.MILLISECONDS.toSeconds(millis),
+        seconds = millis.toDouble() / 1000,
         sizeByte = contentLength,
         featureTag = featureTag,
       )

--- a/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/remote/GetEvaluationsResult.kt
+++ b/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/remote/GetEvaluationsResult.kt
@@ -6,7 +6,7 @@ import io.bucketeer.sdk.android.internal.model.response.GetEvaluationsResponse
 sealed class GetEvaluationsResult {
   data class Success(
     val value: GetEvaluationsResponse,
-    val seconds: Long,
+    val seconds: Double,
     val sizeByte: Int,
     val featureTag: String,
   ) : GetEvaluationsResult()

--- a/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/internal/event/EventInteractorTest.kt
+++ b/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/internal/event/EventInteractorTest.kt
@@ -218,7 +218,7 @@ class EventInteractorTest {
 
     interactor.setEventUpdateListener(listener)
 
-    interactor.trackFetchEvaluationsSuccess("feature_tag_value", 1, 723)
+    interactor.trackFetchEvaluationsSuccess("feature_tag_value", 1.1, 723)
 
     assertThat(listener.calls).hasSize(1)
     assertThat(listener.calls[0]).hasSize(2)
@@ -240,7 +240,7 @@ class EventInteractorTest {
             labels = mapOf(
               "tag" to "feature_tag_value",
             ),
-            latencySecond = 1.0,
+            latencySecond = 1.1,
           ),
           sdkVersion = BuildConfig.SDK_VERSION,
           metadata = mapOf(
@@ -377,7 +377,7 @@ class EventInteractorTest {
         ),
     )
 
-    interactor.trackFetchEvaluationsSuccess("feature_tag_value", 1, 723)
+    interactor.trackFetchEvaluationsSuccess("feature_tag_value", 0.1, 723)
     interactor.trackGoalEvent("feature_tag_value", user1, "goal_id_value", 0.5)
     interactor.trackGoalEvent("feature_tag_value", user1, "goal_id_value2", 0.4)
 
@@ -406,7 +406,7 @@ class EventInteractorTest {
                 labels = mapOf(
                   "tag" to "feature_tag_value",
                 ),
-                latencySecond = 1.0,
+                latencySecond = 0.1,
               ),
               sdkVersion = BuildConfig.SDK_VERSION,
               metadata = mapOf(
@@ -483,7 +483,7 @@ class EventInteractorTest {
         ),
     )
 
-    interactor.trackFetchEvaluationsSuccess("feature_tag_value", 1, 723)
+    interactor.trackFetchEvaluationsSuccess("feature_tag_value", 0.1, 723)
     interactor.trackGoalEvent("feature_tag_value", user1, "goal_id_value", 0.5)
 
     assertThat(component.dataModule.eventDao.getEvents()).hasSize(3)
@@ -515,7 +515,7 @@ class EventInteractorTest {
             labels = mapOf(
               "tag" to "feature_tag_value",
             ),
-            latencySecond = 1.0,
+            latencySecond = 0.1,
           ),
           sdkVersion = BuildConfig.SDK_VERSION,
           metadata = mapOf(
@@ -625,7 +625,7 @@ class EventInteractorTest {
         ),
     )
 
-    interactor.trackFetchEvaluationsSuccess("feature_tag_value", 1, 723)
+    interactor.trackFetchEvaluationsSuccess("feature_tag_value", 0.1, 723)
 
     assertThat(component.dataModule.eventDao.getEvents()).hasSize(2)
 
@@ -651,7 +651,7 @@ class EventInteractorTest {
         ),
     )
 
-    interactor.trackFetchEvaluationsSuccess("feature_tag_value", 1, 723)
+    interactor.trackFetchEvaluationsSuccess("feature_tag_value", 0.1, 723)
 
     val result = interactor.sendEvents(force = true)
 
@@ -678,7 +678,7 @@ class EventInteractorTest {
                 labels = mapOf(
                   "tag" to "feature_tag_value",
                 ),
-                latencySecond = 1.0,
+                latencySecond = 0.1,
               ),
               sdkVersion = BuildConfig.SDK_VERSION,
               metadata = mapOf(
@@ -718,7 +718,7 @@ class EventInteractorTest {
 
   @Test
   fun `sendEvents - retriable error`() {
-    interactor.trackFetchEvaluationsSuccess("feature_tag_value", 1, 723)
+    interactor.trackFetchEvaluationsSuccess("feature_tag_value", 0.1, 723)
     interactor.trackGoalEvent("feature_tag_value", user1, "goal_id_value", 0.5)
     interactor.trackGoalEvent("feature_tag_value", user1, "goal_id_value2", 0.4)
 
@@ -762,7 +762,7 @@ class EventInteractorTest {
                 labels = mapOf(
                   "tag" to "feature_tag_value",
                 ),
-                latencySecond = 1.0,
+                latencySecond = 0.1,
               ),
               sdkVersion = BuildConfig.SDK_VERSION,
               metadata = mapOf(
@@ -833,7 +833,7 @@ class EventInteractorTest {
               labels = mapOf(
                 "tag" to "feature_tag_value",
               ),
-              latencySecond = 1.0,
+              latencySecond = 0.1,
             ),
             sdkVersion = BuildConfig.SDK_VERSION,
             metadata = mapOf(


### PR DESCRIPTION
- When the response time is lower than 1 second, the latencySeconds field was set to `0` because the Long is an integer type.