### PR TITLE
chore: change timeout type from float to double

### DIFF
--- a/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/event/EventCreators.kt
+++ b/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/event/EventCreators.kt
@@ -253,7 +253,7 @@ internal fun newEventDataMetricEvent(
           apiId = apiId,
           labels = labels.apply {
             // https://github.com/bucketeer-io/android-client-sdk/issues/81
-            set("timeout", (error.timeoutMillis / 1000f).toString())
+            set("timeout", (error.timeoutMillis / 1000.0).toString())
           },
         ),
       )


### PR DESCRIPTION
Fix https://github.com/bucketeer-io/android-client-sdk/issues/112