### PR TITLE
chore: lose the main thread dependency in the initialize and destroy implementation

### DIFF
--- a/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/BKTClient.kt
+++ b/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/BKTClient.kt
@@ -1,7 +1,6 @@
 package io.bucketeer.sdk.android
 
 import android.content.Context
-import androidx.annotation.MainThread
 import io.bucketeer.sdk.android.internal.LoggerHolder
 import io.bucketeer.sdk.android.internal.logw
 import io.bucketeer.sdk.android.internal.util.Futures
@@ -50,7 +49,6 @@ interface BKTClient {
       }
     }
 
-    @MainThread
     fun initialize(
       context: Context,
       config: BKTConfig,
@@ -75,7 +73,6 @@ interface BKTClient {
       }
     }
 
-    @MainThread
     fun destroy() {
       synchronized(this) {
         val client = instance ?: return
@@ -86,7 +83,7 @@ interface BKTClient {
   }
 
   fun interface EvaluationUpdateListener {
-    @MainThread
+    // The listener callback is called on the main thread.
     fun onUpdate()
   }
 }


### PR DESCRIPTION
Because the SDK uses the Lifecycle observer API, it must be called on the main thread.
However, the SDK should also be able to be initialized and destroyed on a non-main thread.

I have changed it to use the main handler when using the lifecycle observer.