### PR TITLE
fix: null pointer exception when destroy and reinitialize the client SDK

### DIFF
--- a/bucketeer/src/androidTest/kotlin/io/bucketeer/sdk/android/e2e/BKTClientEvaluationUpdateTests.kt
+++ b/bucketeer/src/androidTest/kotlin/io/bucketeer/sdk/android/e2e/BKTClientEvaluationUpdateTests.kt
@@ -164,6 +164,12 @@ class BKTClientEvaluationUpdateTests {
   }
 
   @Test
+  fun testInitializeWithNewFeatureTagInNoneUIThread() {
+    // One more test to see what happen with we destroy & reinitialize the sdk from a normal thread.
+    testInitializeWithNewFeatureTag()
+  }
+
+  @Test
   @UiThreadTest
   fun testInitWithoutFeatureTagShouldRetrievesAllFeatures() {
     config = BKTConfig.builder()

--- a/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/BKTClientImpl.kt
+++ b/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/BKTClientImpl.kt
@@ -170,7 +170,7 @@ internal class BKTClientImpl(
   private fun scheduleTasks() {
     taskScheduler = TaskScheduler(component, executor)
     // Lifecycle observer must be executed on the main thread
-    mainHandler.post {
+    runOnMainThread {
       ProcessLifecycleOwner.get().lifecycle.addObserver(taskScheduler!!)
     }
   }
@@ -179,11 +179,21 @@ internal class BKTClientImpl(
     taskScheduler?.let {
       it.stop()
       // Lifecycle observer must be executed on the main thread
-      mainHandler.post {
+      runOnMainThread {
         ProcessLifecycleOwner.get().lifecycle.removeObserver(it)
       }
     }
     taskScheduler = null
+  }
+
+  private fun runOnMainThread(block: () -> Unit) {
+    if (Looper.myLooper() == Looper.getMainLooper()) {
+      // Currently on the main thread, execute immediately
+      block()
+    } else {
+      // Not on the main thread, post to the main thread
+      mainHandler.post(block)
+    }
   }
 
   companion object {

--- a/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/BKTClientImpl.kt
+++ b/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/BKTClientImpl.kt
@@ -168,22 +168,22 @@ internal class BKTClientImpl(
   }
 
   private fun scheduleTasks() {
-    taskScheduler = TaskScheduler(component, executor)
     // Lifecycle observer must be executed on the main thread
     runOnMainThread {
+      taskScheduler = TaskScheduler(component, executor)
       ProcessLifecycleOwner.get().lifecycle.addObserver(taskScheduler!!)
     }
   }
 
   internal fun resetTasks() {
-    taskScheduler?.let {
-      it.stop()
-      // Lifecycle observer must be executed on the main thread
-      runOnMainThread {
+    runOnMainThread {
+      taskScheduler?.let {
+        it.stop()
+        // Lifecycle observer must be executed on the main thread
         ProcessLifecycleOwner.get().lifecycle.removeObserver(it)
       }
+      taskScheduler = null
     }
-    taskScheduler = null
   }
 
   private fun runOnMainThread(block: () -> Unit) {

--- a/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/BKTClientImplTest.kt
+++ b/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/BKTClientImplTest.kt
@@ -237,7 +237,6 @@ class BKTClientImplTest {
     }
   }
 
-
   @Test
   @LooperMode(LooperMode.Mode.PAUSED)
   fun destroyAndReinitializeImmediately() {
@@ -265,7 +264,6 @@ class BKTClientImplTest {
     assertThat(BKTClient.getInstance()).isInstanceOf(BKTClient::class.java)
 
     BKTClient.destroy()
-
 
     assertThrows(BKTException.IllegalArgumentException::class.java) {
       BKTClient.getInstance()

--- a/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/BKTClientImplTest.kt
+++ b/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/BKTClientImplTest.kt
@@ -1,5 +1,6 @@
 package io.bucketeer.sdk.android
 
+import android.os.Looper
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import com.squareup.moshi.Moshi
@@ -29,6 +30,8 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows
+import org.robolectric.annotation.LooperMode
 import java.util.concurrent.TimeUnit
 
 @RunWith(RobolectricTestRunner::class)
@@ -232,6 +235,53 @@ class BKTClientImplTest {
     assertThrows(BKTException.IllegalArgumentException::class.java) {
       BKTClient.getInstance()
     }
+  }
+
+
+  @Test
+  @LooperMode(LooperMode.Mode.PAUSED)
+  fun destroyAndReinitializeImmediately() {
+    server.enqueue(
+      MockResponse()
+        .setResponseCode(200)
+        .setBody(
+          moshi.adapter(GetEvaluationsResponse::class.java)
+            .toJson(
+              GetEvaluationsResponse(
+                evaluations = user1Evaluations,
+                userEvaluationsId = "user_evaluations_id_value",
+              ),
+            ),
+        ),
+    )
+
+    BKTClient.initialize(
+      ApplicationProvider.getApplicationContext(),
+      config,
+      user1.toBKTUser(),
+      1000,
+    )
+
+    assertThat(BKTClient.getInstance()).isInstanceOf(BKTClient::class.java)
+
+    BKTClient.destroy()
+
+
+    assertThrows(BKTException.IllegalArgumentException::class.java) {
+      BKTClient.getInstance()
+    }
+
+    BKTClient.initialize(
+      ApplicationProvider.getApplicationContext(),
+      config,
+      user1.toBKTUser(),
+      1000,
+    )
+
+    // Allow all code that posted to the main run loop for executing here
+    Shadows.shadowOf(Looper.getMainLooper()).idle()
+
+    assertThat(BKTClient.getInstance()).isInstanceOf(BKTClient::class.java)
   }
 
   @Test


### PR DESCRIPTION
The E2E tests has been failed https://github.com/bucketeer-io/android-client-sdk/actions/runs/8165990303/job/22324131983

On the recents changes, we add some [codes](https://github.com/bucketeer-io/android-client-sdk/pull/129/files) to run on the `mainHandler.post{}` 
it will not run immediately. It will be scheduled and caused the NPE.

### Changes
- [x] Move all code related to `taskScheduler` & `ProcessLifecycleOwner` to run on the `MainThread`.
- [x] Only post to run on the `MainThread` if needed, and skip do it if we are already on the `MainThread`. 