### PR TITLE
chore: (sample app) enable switching user and tag during runtime.

### DIFF
--- a/sample/src/main/java/io/bucketeer/sample/App.kt
+++ b/sample/src/main/java/io/bucketeer/sample/App.kt
@@ -1,76 +1,13 @@
 package io.bucketeer.sample
 
 import android.app.Application
-import android.content.Context
-import android.widget.Toast
 import androidx.lifecycle.LifecycleObserver
 import com.facebook.stetho.Stetho
-import io.bucketeer.sdk.android.BKTClient
-import io.bucketeer.sdk.android.BKTConfig
-import io.bucketeer.sdk.android.BKTUser
-import io.bucketeer.sdk.android.sample.BuildConfig
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.MainScope
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
-import java.util.concurrent.TimeUnit
 
 class App : Application(), LifecycleObserver {
-  private val sharedPref by lazy {
-    getSharedPreferences(
-      Constants.PREFERENCE_FILE_KEY,
-      Context.MODE_PRIVATE,
-    )
-  }
-
   override fun onCreate() {
     super.onCreate()
     Stetho.initializeWithDefaults(this)
-    initBucketeer()
-  }
-
-  private fun initBucketeer() {
-    val config =
-      BKTConfig.builder()
-        .apiKey(BuildConfig.API_KEY)
-        .apiEndpoint(BuildConfig.API_ENDPOINT)
-        .featureTag(getTag())
-        .appVersion(BuildConfig.VERSION_NAME)
-        .eventsMaxQueueSize(10)
-        .pollingInterval(TimeUnit.SECONDS.toMillis(20))
-        .backgroundPollingInterval(TimeUnit.SECONDS.toMillis(60))
-        .eventsFlushInterval(TimeUnit.SECONDS.toMillis(20))
-        .build()
-
-    val user =
-      BKTUser.builder()
-        .id(getUserId())
-        .build()
-
-    val future = BKTClient.initialize(this, config, user)
-
-    MainScope().launch {
-      val result =
-        withContext(Dispatchers.IO) {
-          future.get()
-        }
-      println("result: $result")
-      Toast.makeText(this@App, "User Evaluations has been updated", Toast.LENGTH_LONG).show()
-    }
-  }
-
-  private fun getTag(): String {
-    return sharedPref.getString(
-      Constants.PREFERENCE_KEY_TAG,
-      Constants.DEFAULT_TAG,
-    ) ?: Constants.DEFAULT_TAG
-  }
-
-  private fun getUserId(): String {
-    return sharedPref.getString(
-      Constants.PREFERENCE_KEY_USER_ID,
-      Constants.DEFAULT_USER_ID,
-    ) ?: Constants.DEFAULT_USER_ID
   }
 
   companion object {

--- a/sample/src/main/java/io/bucketeer/sample/MainActivity.kt
+++ b/sample/src/main/java/io/bucketeer/sample/MainActivity.kt
@@ -44,11 +44,12 @@ class MainActivity : FragmentActivity() {
     super.onCreate(savedInstanceState)
     setContentView(R.layout.activity_main)
     variantTypeSpinner = findViewById(R.id.spinner)
-    val adapter = ArrayAdapter(
-      this,
-      android.R.layout.simple_spinner_item,
-      VariantType.entries.map { it.type },
-    )
+    val adapter =
+      ArrayAdapter(
+        this,
+        android.R.layout.simple_spinner_item,
+        VariantType.entries.map { it.type },
+      )
     adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)
     variantTypeSpinner.adapter = adapter
 
@@ -94,13 +95,14 @@ class MainActivity : FragmentActivity() {
     inputGetVariation.error = null
     val type = VariantType.entries.getOrNull(variantTypeSpinner.selectedItemPosition) ?: VariantType.BOOLEAN
     val client = BKTClient.getInstance()
-    val variation: Any = when (type) {
-      VariantType.INT -> client.intVariation(featureId, 0)
-      VariantType.STRING -> client.stringVariation(featureId, "")
-      VariantType.BOOLEAN -> client.booleanVariation(featureId, false)
-      VariantType.DOUBLE -> client.doubleVariation(featureId, 0.0)
-      VariantType.JSON -> client.jsonVariation(featureId, JSONObject())
-    }
+    val variation: Any =
+      when (type) {
+        VariantType.INT -> client.intVariation(featureId, 0)
+        VariantType.STRING -> client.stringVariation(featureId, "")
+        VariantType.BOOLEAN -> client.booleanVariation(featureId, false)
+        VariantType.DOUBLE -> client.doubleVariation(featureId, 0.0)
+        VariantType.JSON -> client.jsonVariation(featureId, JSONObject())
+      }
     with(sharedPref.edit()) {
       putString(Constants.PREFERENCE_KEY_FEATURE_FLAG_ID, featureId)
       commit()

--- a/sample/src/main/res/layout/activity_main.xml
+++ b/sample/src/main/res/layout/activity_main.xml
@@ -25,12 +25,37 @@
             android:textSize="@dimen/font_size_12" />
     </com.google.android.material.textfield.TextInputLayout>
 
-    <Button
-        android:id="@+id/btn_get_variation"
-        android:layout_width="@dimen/btn_width_200"
+    <LinearLayout
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_gravity="center_horizontal"
-        android:text="@string/btn_get_variation" />
+        android:orientation="horizontal"
+        android:paddingBottom="16dp">
+
+        <LinearLayout
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:orientation="vertical">
+
+            <TextView
+                android:id="@+id/textView"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/variant_type" />
+
+            <Spinner
+                android:id="@+id/spinner"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
+        </LinearLayout>
+
+        <Button
+            android:id="@+id/btn_get_variation"
+            android:layout_width="@dimen/btn_width_200"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_horizontal"
+            android:text="@string/btn_get_variation" />
+    </LinearLayout>
 
     <com.google.android.material.textfield.TextInputLayout
         android:id="@+id/goal_id"

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -8,12 +8,12 @@
     <string name="app_will_be_restarted">The app will be restarted for the changes to take effect</string>
 
     <string name="btn_switch_tag">Switch Tag</string>
-    <string name="btn_get_variation">Get boolean variation</string>
+    <string name="btn_get_variation">Get variation</string>
     <string name="btn_send_goal">Send goal</string>
     <string name="btn_switch_user">Switch user</string>
 
     <string name="dialog_btn_ok">OK</string>
-    <string name="dialog_get_variation">Variation: %1$b</string>
+    <string name="dialog_get_variation">Variation: %1$s</string>
     <string name="dialog_evaluations_updated">User Evaluations has been updated</string>
     <string name="dialog_goal_event_queued">Goal event is queued. It will be sent within 1 minute</string>
 
@@ -21,4 +21,5 @@
     <string name="error_goal_id_required">Goal Id is required</string>
     <string name="error_user_id_required">User Id is required</string>
     <string name="error_tag_id_required">Tag is required</string>
+    <string name="variant_type">Variant Type</string>
 </resources>

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -8,7 +8,7 @@
     <string name="app_will_be_restarted">The app will be restarted for the changes to take effect</string>
 
     <string name="btn_switch_tag">Switch Tag</string>
-    <string name="btn_get_variation">Get variation</string>
+    <string name="btn_get_variation">Get boolean variation</string>
     <string name="btn_send_goal">Send goal</string>
     <string name="btn_switch_user">Switch user</string>
 


### PR DESCRIPTION
### Changes
- No need to restart the sample app after changing the user, tag
- Update the demo app following up the documents
- Add a picker for selecting difference types of variants for testing (int, boolean, string, double, JSON)

<image src='https://github.com/bucketeer-io/android-client-sdk/assets/2597710/d796abea-f8d7-4fdc-8a90-81888796bbc4' width=300px>
<image src='https://github.com/bucketeer-io/android-client-sdk/assets/2597710/ed826e89-fbc2-4d39-b014-1c0740cf3453' width=300px>

