### PR TITLE
fix: capture all potential errors when fetching evaluations

### DIFF
--- a/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/evaluation/EvaluationInteractor.kt
+++ b/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/evaluation/EvaluationInteractor.kt
@@ -57,10 +57,12 @@ internal class EvaluationInteractor(
   ): GetEvaluationsResult {
     var featureTag: String? = null
     try {
+      featureTag = evaluationStorage.getFeatureTag()
+
       val currentEvaluationsId = evaluationStorage.getCurrentEvaluationId()
       val evaluatedAt = evaluationStorage.getEvaluatedAt()
       val userAttributesUpdated = evaluationStorage.getUserAttributesUpdated().toString()
-      featureTag = evaluationStorage.getFeatureTag()
+
       val condition =
         UserEvaluationCondition(
           evaluatedAt = evaluatedAt,

--- a/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/evaluation/EvaluationInteractor.kt
+++ b/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/evaluation/EvaluationInteractor.kt
@@ -117,6 +117,7 @@ internal class EvaluationInteractor(
           if (shouldNotifyListener) {
             mainHandler.post {
               updateListeners.forEach {
+                // Prevent crash if consumer code throwing unhandled error
                 runCatching {
                   it.value.onUpdate()
                 }.onFailure { onUpdateError ->

--- a/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/evaluation/EvaluationInteractor.kt
+++ b/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/evaluation/EvaluationInteractor.kt
@@ -142,7 +142,7 @@ internal class EvaluationInteractor(
       featureTag = evaluationStorage.getFeatureTag()
       return getEvaluations(user = user, timeoutMillis = timeoutMillis)
     } catch (ex: Exception) {
-      loge { "Failed to update latest evaluations" }
+      loge(ex) { "failed when fetching evaluations: ${ex.message}" }
       return GetEvaluationsResult.Failure(
         BKTException.IllegalStateException("error: ${ex.message}"),
         featureTag ?: "",

--- a/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/evaluation/EvaluationInteractor.kt
+++ b/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/evaluation/EvaluationInteractor.kt
@@ -144,7 +144,7 @@ internal class EvaluationInteractor(
     } catch (ex: Exception) {
       loge(ex) { "failed when fetching evaluations: ${ex.message}" }
       return GetEvaluationsResult.Failure(
-        BKTException.IllegalStateException("error: ${ex.message}"),
+        BKTException.IllegalStateException("failed when fetching evaluations: ${ex.message}"),
         featureTag ?: "",
       )
     }

--- a/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/evaluation/EvaluationInteractor.kt
+++ b/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/evaluation/EvaluationInteractor.kt
@@ -116,7 +116,13 @@ internal class EvaluationInteractor(
           // to avoid unintentional lock on Interactor's execution thread.
           if (shouldNotifyListener) {
             mainHandler.post {
-              updateListeners.forEach { it.value.onUpdate() }
+              updateListeners.forEach {
+                runCatching {
+                  it.value.onUpdate()
+                }.onFailure { onUpdateError ->
+                  logd(onUpdateError) { "onUpdateError: ${onUpdateError.message}" }
+                }
+              }
             }
           }
         }

--- a/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/evaluation/cache/EvaluationSharedPrefsImpl.kt
+++ b/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/evaluation/cache/EvaluationSharedPrefsImpl.kt
@@ -1,6 +1,5 @@
 package io.bucketeer.sdk.android.internal.evaluation.cache
 
-import android.annotation.SuppressLint
 import android.content.SharedPreferences
 import io.bucketeer.sdk.android.internal.Constants
 
@@ -10,23 +9,21 @@ internal class EvaluationSharedPrefsImpl(
   override var currentEvaluationsId: String
     get() = sharedPrefs.getString(Constants.PREFERENCE_KEY_USER_EVALUATION_ID, "") ?: ""
 
-    @SuppressLint("ApplySharedPref")
     set(value) {
       sharedPrefs
         .edit()
         .putString(Constants.PREFERENCE_KEY_USER_EVALUATION_ID, value)
-        .commit()
+        .apply()
     }
 
   override var featureTag: String
     get() = sharedPrefs.getString(Constants.PREFERENCE_KEY_FEATURE_TAG, "") ?: ""
 
-    @SuppressLint("ApplySharedPref")
     set(value) {
       sharedPrefs
         .edit()
         .putString(Constants.PREFERENCE_KEY_FEATURE_TAG, value)
-        .commit()
+        .apply()
     }
 
   // https://github.com/bucketeer-io/android-client-sdk/issues/69
@@ -36,21 +33,19 @@ internal class EvaluationSharedPrefsImpl(
   override var evaluatedAt: String
     get() = sharedPrefs.getString(Constants.PREFERENCE_KEY_EVALUATED_AT, "0") ?: "0"
 
-    @SuppressLint("ApplySharedPref")
     set(value) {
       sharedPrefs
         .edit()
         .putString(Constants.PREFERENCE_KEY_EVALUATED_AT, value)
-        .commit()
+        .apply()
     }
   override var userAttributesUpdated: Boolean
     get() = sharedPrefs.getBoolean(Constants.PREFERENCE_KEY_USER_ATTRIBUTES_UPDATED, false)
 
-    @SuppressLint("ApplySharedPref")
     set(value) {
       sharedPrefs
         .edit()
         .putBoolean(Constants.PREFERENCE_KEY_USER_ATTRIBUTES_UPDATED, value)
-        .commit()
+        .apply()
     }
 }

--- a/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/evaluation/cache/EvaluationSharedPrefsImpl.kt
+++ b/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/evaluation/cache/EvaluationSharedPrefsImpl.kt
@@ -1,5 +1,6 @@
 package io.bucketeer.sdk.android.internal.evaluation.cache
 
+import android.annotation.SuppressLint
 import android.content.SharedPreferences
 import io.bucketeer.sdk.android.internal.Constants
 
@@ -9,21 +10,23 @@ internal class EvaluationSharedPrefsImpl(
   override var currentEvaluationsId: String
     get() = sharedPrefs.getString(Constants.PREFERENCE_KEY_USER_EVALUATION_ID, "") ?: ""
 
+    @SuppressLint("ApplySharedPref")
     set(value) {
       sharedPrefs
         .edit()
         .putString(Constants.PREFERENCE_KEY_USER_EVALUATION_ID, value)
-        .apply()
+        .commit()
     }
 
   override var featureTag: String
     get() = sharedPrefs.getString(Constants.PREFERENCE_KEY_FEATURE_TAG, "") ?: ""
 
+    @SuppressLint("ApplySharedPref")
     set(value) {
       sharedPrefs
         .edit()
         .putString(Constants.PREFERENCE_KEY_FEATURE_TAG, value)
-        .apply()
+        .commit()
     }
 
   // https://github.com/bucketeer-io/android-client-sdk/issues/69
@@ -33,19 +36,21 @@ internal class EvaluationSharedPrefsImpl(
   override var evaluatedAt: String
     get() = sharedPrefs.getString(Constants.PREFERENCE_KEY_EVALUATED_AT, "0") ?: "0"
 
+    @SuppressLint("ApplySharedPref")
     set(value) {
       sharedPrefs
         .edit()
         .putString(Constants.PREFERENCE_KEY_EVALUATED_AT, value)
-        .apply()
+        .commit()
     }
   override var userAttributesUpdated: Boolean
     get() = sharedPrefs.getBoolean(Constants.PREFERENCE_KEY_USER_ATTRIBUTES_UPDATED, false)
 
+    @SuppressLint("ApplySharedPref")
     set(value) {
       sharedPrefs
         .edit()
         .putBoolean(Constants.PREFERENCE_KEY_USER_ATTRIBUTES_UPDATED, value)
-        .apply()
+        .commit()
     }
 }

--- a/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/event/EventCreators.kt
+++ b/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/event/EventCreators.kt
@@ -288,7 +288,9 @@ internal fun newEventDataMetricEvent(
           MetricsEventType.UNKNOWN,
           MetricsEventData.UnknownErrorMetricsEvent(
             apiId = apiId,
-            labels = labels,
+            labels = labels.apply {
+              set("error_message", error.message ?: "UnknownException")
+            },
           ),
         )
 

--- a/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/event/EventCreators.kt
+++ b/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/event/EventCreators.kt
@@ -288,9 +288,10 @@ internal fun newEventDataMetricEvent(
           MetricsEventType.UNKNOWN,
           MetricsEventData.UnknownErrorMetricsEvent(
             apiId = apiId,
-            labels = labels.apply {
-              set("error_message", error.message ?: "UnknownException")
-            },
+            labels =
+              labels.apply {
+                set("error_message", error.message ?: "UnknownException")
+              },
           ),
         )
 

--- a/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/internal/evaluation/EvaluationInteractorCaptureErrorTests.kt
+++ b/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/internal/evaluation/EvaluationInteractorCaptureErrorTests.kt
@@ -84,19 +84,19 @@ class EvaluationInteractorCaptureErrorTests {
       apiClient = MockReturnSuccessAPIClient(),
       storage = MockEvaluationStorage("test_user_1", getUserAttributesUpdatedError = Exception("getUserAttributesUpdatedError")),
       expected =
-      GetEvaluationsResult.Failure(
-        BKTException.IllegalStateException("error: getUserAttributesUpdatedError"),
-        "feature_tag_value",
-      ),
+        GetEvaluationsResult.Failure(
+          BKTException.IllegalStateException("error: getUserAttributesUpdatedError"),
+          "feature_tag_value",
+        ),
     ),
     STORAGE_ERROR_3(
       apiClient = MockReturnSuccessAPIClient(),
       storage = MockEvaluationStorage("test_user_1", clearUserAttributesUpdatedError = Exception("clearUserAttributesUpdatedError")),
       expected =
-      GetEvaluationsResult.Failure(
-        BKTException.IllegalStateException("error: clearUserAttributesUpdatedError"),
-        "feature_tag_value",
-      ),
+        GetEvaluationsResult.Failure(
+          BKTException.IllegalStateException("error: clearUserAttributesUpdatedError"),
+          "feature_tag_value",
+        ),
     ),
   }
 }
@@ -216,9 +216,7 @@ private class MockEvaluationStorage(
     evaluations: List<Evaluation>,
     archivedFeatureIds: List<String>,
     evaluatedAt: String,
-  ): Boolean {
-    return true
-  }
+  ): Boolean = true
 
   override fun refreshCache() {}
 }

--- a/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/internal/evaluation/EvaluationInteractorCaptureErrorTests.kt
+++ b/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/internal/evaluation/EvaluationInteractorCaptureErrorTests.kt
@@ -76,7 +76,7 @@ class EvaluationInteractorCaptureErrorTests {
       storage = MockEvaluationStorage("test_user_1", deleteAllAndInsertError = Exception("deleteAllAndInsert")),
       expected =
         GetEvaluationsResult.Failure(
-          BKTException.IllegalStateException("error: deleteAllAndInsert"),
+          BKTException.IllegalStateException("failed when fetching evaluations: deleteAllAndInsert"),
           "feature_tag_value",
         ),
     ),
@@ -85,7 +85,7 @@ class EvaluationInteractorCaptureErrorTests {
       storage = MockEvaluationStorage("test_user_1", getUserAttributesUpdatedError = Exception("getUserAttributesUpdatedError")),
       expected =
         GetEvaluationsResult.Failure(
-          BKTException.IllegalStateException("error: getUserAttributesUpdatedError"),
+          BKTException.IllegalStateException("failed when fetching evaluations: getUserAttributesUpdatedError"),
           "feature_tag_value",
         ),
     ),
@@ -94,7 +94,7 @@ class EvaluationInteractorCaptureErrorTests {
       storage = MockEvaluationStorage("test_user_1", clearUserAttributesUpdatedError = Exception("clearUserAttributesUpdatedError")),
       expected =
         GetEvaluationsResult.Failure(
-          BKTException.IllegalStateException("error: clearUserAttributesUpdatedError"),
+          BKTException.IllegalStateException("failed when fetching evaluations: clearUserAttributesUpdatedError"),
           "feature_tag_value",
         ),
     ),

--- a/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/internal/evaluation/EvaluationInteractorCaptureErrorTests.kt
+++ b/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/internal/evaluation/EvaluationInteractorCaptureErrorTests.kt
@@ -71,14 +71,32 @@ class EvaluationInteractorCaptureErrorTests {
           featureTag = "feature_tag_value",
         ),
     ),
-    STORAGE_ERROR(
+    STORAGE_ERROR_1(
       apiClient = MockReturnSuccessAPIClient(),
-      storage = MockEvaluationStorage("test_user_1"),
+      storage = MockEvaluationStorage("test_user_1", deleteAllAndInsertError = Exception("deleteAllAndInsert")),
       expected =
         GetEvaluationsResult.Failure(
-          BKTException.IllegalStateException("error: runtime exception"),
+          BKTException.IllegalStateException("error: deleteAllAndInsert"),
           "feature_tag_value",
         ),
+    ),
+    STORAGE_ERROR_2(
+      apiClient = MockReturnSuccessAPIClient(),
+      storage = MockEvaluationStorage("test_user_1", getUserAttributesUpdatedError = Exception("getUserAttributesUpdatedError")),
+      expected =
+      GetEvaluationsResult.Failure(
+        BKTException.IllegalStateException("error: getUserAttributesUpdatedError"),
+        "feature_tag_value",
+      ),
+    ),
+    STORAGE_ERROR_3(
+      apiClient = MockReturnSuccessAPIClient(),
+      storage = MockEvaluationStorage("test_user_1", clearUserAttributesUpdatedError = Exception("clearUserAttributesUpdatedError")),
+      expected =
+      GetEvaluationsResult.Failure(
+        BKTException.IllegalStateException("error: clearUserAttributesUpdatedError"),
+        "feature_tag_value",
+      ),
     ),
   }
 }
@@ -146,6 +164,9 @@ private class MockErrorAPIClient : ApiClient {
 
 private class MockEvaluationStorage(
   override val userId: String,
+  val clearUserAttributesUpdatedError: Throwable? = null,
+  val getUserAttributesUpdatedError: Throwable? = null,
+  val deleteAllAndInsertError: Throwable? = null,
 ) : EvaluationStorage {
   private var featureTag = ""
 
@@ -155,9 +176,18 @@ private class MockEvaluationStorage(
 
   override fun setUserAttributesUpdated() {}
 
-  override fun clearUserAttributesUpdated() {}
+  override fun clearUserAttributesUpdated() {
+    if (clearUserAttributesUpdatedError != null) {
+      throw clearUserAttributesUpdatedError
+    }
+  }
 
-  override fun getUserAttributesUpdated(): Boolean = false
+  override fun getUserAttributesUpdated(): Boolean {
+    if (getUserAttributesUpdatedError != null) {
+      throw getUserAttributesUpdatedError
+    }
+    return false
+  }
 
   override fun getEvaluatedAt(): String = "0"
 
@@ -175,14 +205,20 @@ private class MockEvaluationStorage(
     evaluationsId: String,
     evaluations: List<Evaluation>,
     evaluatedAt: String,
-  ): Unit = throw Exception("runtime exception")
+  ) {
+    if (deleteAllAndInsertError != null) {
+      throw deleteAllAndInsertError
+    }
+  }
 
   override fun update(
     evaluationsId: String,
     evaluations: List<Evaluation>,
     archivedFeatureIds: List<String>,
     evaluatedAt: String,
-  ): Boolean = throw Exception("runtime exception")
+  ): Boolean {
+    return true
+  }
 
   override fun refreshCache() {}
 }

--- a/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/internal/event/BKTExceptionToEventDataMetricEventTest.kt
+++ b/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/internal/event/BKTExceptionToEventDataMetricEventTest.kt
@@ -22,6 +22,8 @@ class BKTExceptionToEventDataMetricEventTest {
     val expectedLabelsForRedirectRequestException = mapOf("tag" to "android", "response_code" to "302")
     val expectedLabelsForUnknownServerException =
       mapOf("tag" to "android", "response_code" to "499", "error_message" to "UnknownServerException")
+    val expectedLabelsForUnknownException =
+      mapOf("tag" to "android", "error_message" to "UnknownException")
     val expectedApiId = ApiId.GET_EVALUATIONS
     val expectedMetadata = newMetadata("1.0.0")
   }
@@ -212,14 +214,14 @@ class BKTExceptionToEventDataMetricEventTest {
       ),
     ),
     UNKNOWN(
-      BKTException.UnknownException(message = ""),
+      BKTException.UnknownException(message = "UnknownException"),
       EventData.MetricsEvent(
         timestamp = EXPECTED_TIMESTAMP,
         type = MetricsEventType.UNKNOWN,
         event =
           MetricsEventData.UnknownErrorMetricsEvent(
             apiId = expectedApiId,
-            labels = expectedLabelsForOtherCases,
+            labels = expectedLabelsForUnknownException,
           ),
         sourceId = SourceID.ANDROID,
         sdkVersion = BuildConfig.SDK_VERSION,


### PR DESCRIPTION
This PR includes 
- Improvements in error handling 
- Removes some suppressed lint warnings
- Fix missing `error_message` when reporting an unknown error from SDK code (it is different case with `unknown error` from the server API)