### PR TITLE
fix: skip generating error events for unauthorized or forbidden errors

### DIFF
--- a/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/event/EventCreators.kt
+++ b/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/event/EventCreators.kt
@@ -165,7 +165,7 @@ internal fun newErrorMetricsEvent(
   apiId: ApiId,
 ): Event? {
   if (error is BKTException.UnauthorizedException || error is BKTException.ForbiddenException) {
-    loge(error) { "Skip generating error events for unauthorized or forbidden errors." }
+    loge(error) { "An unauthorized or forbidden error occurred. Please check your API Key." }
     return null
   }
 

--- a/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/event/EventCreators.kt
+++ b/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/event/EventCreators.kt
@@ -5,6 +5,7 @@ import io.bucketeer.sdk.android.BKTException
 import io.bucketeer.sdk.android.BuildConfig
 import io.bucketeer.sdk.android.internal.Clock
 import io.bucketeer.sdk.android.internal.IdGenerator
+import io.bucketeer.sdk.android.internal.loge
 import io.bucketeer.sdk.android.internal.model.ApiId
 import io.bucketeer.sdk.android.internal.model.Evaluation
 import io.bucketeer.sdk.android.internal.model.Event
@@ -162,8 +163,13 @@ internal fun newErrorMetricsEvent(
   appVersion: String,
   error: BKTException,
   apiId: ApiId,
-): Event =
-  Event(
+): Event? {
+  if (error is BKTException.UnauthorizedException || error is BKTException.ForbiddenException) {
+    loge(error) { "Skip generating error events for unauthorized or forbidden errors." }
+    return null
+  }
+
+  return Event(
     id = idGenerator.newId(),
     type = EventType.METRICS,
     event =
@@ -175,6 +181,7 @@ internal fun newErrorMetricsEvent(
         apiId,
       ),
   )
+}
 
 internal fun newEventDataMetricEvent(
   error: BKTException,

--- a/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/event/EventInteractor.kt
+++ b/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/event/EventInteractor.kt
@@ -109,7 +109,7 @@ internal class EventInteractor(
         error = error,
         apiId = apiId,
       )
-    addMetricEvents(listOf(event))
+    event?.let { addMetricEvents(listOf(event)) }
   }
 
   /*

--- a/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/internal/event/EventCreatorsKtTest.kt
+++ b/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/internal/event/EventCreatorsKtTest.kt
@@ -1,5 +1,9 @@
 package io.bucketeer.sdk.android.internal.event
 
+import io.bucketeer.sdk.android.BKTException
+import io.bucketeer.sdk.android.internal.ClockImpl
+import io.bucketeer.sdk.android.internal.IdGeneratorImpl
+import io.bucketeer.sdk.android.internal.model.ApiId
 import org.junit.Test
 
 class EventCreatorsKtTest {
@@ -10,5 +14,29 @@ class EventCreatorsKtTest {
     assert(500L.toStringInDoubleFormat() == "0.5")
     assert(432L.toStringInDoubleFormat() == "0.432")
     assert(51L.toStringInDoubleFormat() == "0.051")
+  }
+
+  @Test
+  fun testShouldReturnNullWhenUnauthorizedOrForbidden() {
+    val clock = ClockImpl()
+    val idGenerator = IdGeneratorImpl()
+    val featureTag = "testFeatureTag"
+    val appVersion = "1.0.0"
+    val apiId = ApiId.GET_EVALUATIONS
+
+    val unauthorizedException = BKTException.UnauthorizedException("401 error")
+    val forbiddenException = BKTException.ForbiddenException("403 error")
+    val badRequestException = BKTException.BadRequestException("Bad request error")
+    val clientClosedRequestException = BKTException.ClientClosedRequestException("Client closed request error")
+    val internalServerErrorException = BKTException.InternalServerErrorException("Internal server error")
+    val notFoundException = BKTException.FeatureNotFoundException("404 error")
+
+    assert(newErrorMetricsEvent(clock, idGenerator, featureTag, appVersion, unauthorizedException, apiId) == null)
+    assert(newErrorMetricsEvent(clock, idGenerator, featureTag, appVersion, forbiddenException, apiId) == null)
+
+    assert(newErrorMetricsEvent(clock, idGenerator, featureTag, appVersion, badRequestException, apiId) != null)
+    assert(newErrorMetricsEvent(clock, idGenerator, featureTag, appVersion, clientClosedRequestException, apiId) != null)
+    assert(newErrorMetricsEvent(clock, idGenerator, featureTag, appVersion, internalServerErrorException, apiId) != null)
+    assert(newErrorMetricsEvent(clock, idGenerator, featureTag, appVersion, notFoundException, apiId) != null)
   }
 }

--- a/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/internal/event/EventInteractorTest.kt
+++ b/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/internal/event/EventInteractorTest.kt
@@ -397,6 +397,27 @@ class EventInteractorTest {
   }
 
   @Test
+  fun `should not create error event for Unauthorized and ForbiddenExceptions`() {
+    val listener = FakeEventUpdateListener()
+
+    interactor.setEventUpdateListener(listener)
+
+    interactor.trackFetchEvaluationsFailure(
+      "feature_tag_value",
+      BKTException.UnauthorizedException("unauthorized"),
+    )
+
+    assertThat(listener.calls).hasSize(0)
+
+    interactor.trackFetchEvaluationsFailure(
+      "feature_tag_value",
+      BKTException.ForbiddenException("forbidden"),
+    )
+
+    assertThat(listener.calls).hasSize(0)
+  }
+
+  @Test
   fun `sendEvents - success`() {
     server.enqueue(
       MockResponse()


### PR DESCRIPTION
When an invalid API key is used, the SDK will receive a 401 or 403 response. 
Since the key is invalid, the SDK was mistakenly generating error metrics to report these forbidden errors. 
However, because the key is invalid, the SDK is unable to report these events, leading to their accumulation. 
This buildup increases the number of event API requests, resulting in higher logging costs. 

To prevent this, we will skip generating error events for unauthorized (401) or forbidden (403) errors.