### PR TITLE
test: skip feature version checking in the e2e tests

### DIFF
--- a/bucketeer/src/androidTest/kotlin/io/bucketeer/sdk/android/e2e/BKTClientTest.kt
+++ b/bucketeer/src/androidTest/kotlin/io/bucketeer/sdk/android/e2e/BKTClientTest.kt
@@ -93,10 +93,9 @@ class BKTClientTest {
     )
 
     val detailStringEvaluationDetails = client.stringVariationDetails(FEATURE_ID_STRING, defaultValue = "")
-    assertThat(
-      detailStringEvaluationDetails,
-    ).isEqualTo(
-      BKTEvaluationDetails(
+    assertEvaluationDetails(
+      actual = detailStringEvaluationDetails,
+      expected = BKTEvaluationDetails(
         featureId = FEATURE_ID_STRING,
         featureVersion = 4,
         userId = USER_ID,

--- a/bucketeer/src/androidTest/kotlin/io/bucketeer/sdk/android/e2e/BKTClientTest.kt
+++ b/bucketeer/src/androidTest/kotlin/io/bucketeer/sdk/android/e2e/BKTClientTest.kt
@@ -95,15 +95,16 @@ class BKTClientTest {
     val detailStringEvaluationDetails = client.stringVariationDetails(FEATURE_ID_STRING, defaultValue = "")
     assertEvaluationDetails(
       actual = detailStringEvaluationDetails,
-      expected = BKTEvaluationDetails(
-        featureId = FEATURE_ID_STRING,
-        featureVersion = 4,
-        userId = USER_ID,
-        variationId = "b59a19d5-f4b1-47f8-a46e-6d9ca14740c1",
-        variationName = "variation 2",
-        variationValue = "value-2",
-        reason = BKTEvaluationDetails.Reason.RULE,
-      ),
+      expected =
+        BKTEvaluationDetails(
+          featureId = FEATURE_ID_STRING,
+          featureVersion = 4,
+          userId = USER_ID,
+          variationId = "b59a19d5-f4b1-47f8-a46e-6d9ca14740c1",
+          variationName = "variation 2",
+          variationValue = "value-2",
+          reason = BKTEvaluationDetails.Reason.RULE,
+        ),
     )
   }
 }

--- a/bucketeer/src/androidTest/kotlin/io/bucketeer/sdk/android/e2e/BKTClientVariationTest.kt
+++ b/bucketeer/src/androidTest/kotlin/io/bucketeer/sdk/android/e2e/BKTClientVariationTest.kt
@@ -91,10 +91,9 @@ class BKTClientVariationTest {
       ),
     )
 
-    assertThat(
-      BKTClient.getInstance().stringVariationDetails(FEATURE_ID_STRING, defaultValue = "1"),
-    ).isEqualTo(
-      BKTEvaluationDetails(
+    assertEvaluationDetails(
+      actual = BKTClient.getInstance().stringVariationDetails(FEATURE_ID_STRING, defaultValue = "1"),
+      expected = BKTEvaluationDetails(
         featureId = FEATURE_ID_STRING,
         featureVersion = 4,
         userId = USER_ID,
@@ -105,10 +104,9 @@ class BKTClientVariationTest {
       ),
     )
 
-    assertThat(
-      BKTClient.getInstance().objectVariationDetails(FEATURE_ID_STRING, defaultValue = BKTValue.String("1")),
-    ).isEqualTo(
-      BKTEvaluationDetails(
+    assertEvaluationDetails(
+      actual = BKTClient.getInstance().objectVariationDetails(FEATURE_ID_STRING, defaultValue = BKTValue.String("1")),
+      expected = BKTEvaluationDetails(
         featureId = FEATURE_ID_STRING,
         featureVersion = 4,
         userId = USER_ID,
@@ -146,10 +144,9 @@ class BKTClientVariationTest {
       ),
     )
 
-    assertThat(
-      BKTClient.getInstance().intVariationDetails(FEATURE_ID_INT, defaultValue = 1),
-    ).isEqualTo(
-      BKTEvaluationDetails(
+    assertEvaluationDetails(
+      actual = BKTClient.getInstance().intVariationDetails(FEATURE_ID_INT, defaultValue = 1),
+      expected = BKTEvaluationDetails(
         featureId = FEATURE_ID_INT,
         featureVersion = 3,
         userId = USER_ID,
@@ -160,10 +157,9 @@ class BKTClientVariationTest {
       ),
     )
 
-    assertThat(
-      BKTClient.getInstance().objectVariationDetails(FEATURE_ID_INT, defaultValue = BKTValue.Number(1.0)),
-    ).isEqualTo(
-      BKTEvaluationDetails(
+    assertEvaluationDetails(
+      actual = BKTClient.getInstance().objectVariationDetails(FEATURE_ID_INT, defaultValue = BKTValue.Number(1.0)),
+      expected = BKTEvaluationDetails(
         featureId = FEATURE_ID_INT,
         featureVersion = 3,
         userId = USER_ID,
@@ -193,8 +189,8 @@ class BKTClientVariationTest {
   fun doubleVariation_detail() {
     val actual = BKTClient.getInstance().evaluationDetails(FEATURE_ID_DOUBLE)
     assertEvaluation(
-      actual,
-      BKTEvaluation(
+      actual = actual,
+      expected = BKTEvaluation(
         id = "feature-android-e2e-double:3:bucketeer-android-user-id-1",
         featureId = FEATURE_ID_DOUBLE,
         featureVersion = 3,
@@ -206,10 +202,9 @@ class BKTClientVariationTest {
       ),
     )
 
-    assertThat(
-      BKTClient.getInstance().doubleVariationDetails(FEATURE_ID_DOUBLE, defaultValue = 3.4),
-    ).isEqualTo(
-      BKTEvaluationDetails(
+    assertEvaluationDetails(
+      actual = BKTClient.getInstance().doubleVariationDetails(FEATURE_ID_DOUBLE, defaultValue = 3.4),
+      expected = BKTEvaluationDetails(
         featureId = FEATURE_ID_DOUBLE,
         featureVersion = 3,
         userId = USER_ID,
@@ -220,10 +215,9 @@ class BKTClientVariationTest {
       ),
     )
 
-    assertThat(
-      BKTClient.getInstance().intVariationDetails(FEATURE_ID_DOUBLE, defaultValue = 44),
-    ).isEqualTo(
-      BKTEvaluationDetails(
+    assertEvaluationDetails(
+      actual = BKTClient.getInstance().intVariationDetails(FEATURE_ID_DOUBLE, defaultValue = 44),
+      expected = BKTEvaluationDetails(
         featureId = FEATURE_ID_DOUBLE,
         featureVersion = 3,
         userId = USER_ID,
@@ -234,10 +228,9 @@ class BKTClientVariationTest {
       ),
     )
 
-    assertThat(
-      BKTClient.getInstance().objectVariationDetails(FEATURE_ID_DOUBLE, defaultValue = BKTValue.Number(1.0)),
-    ).isEqualTo(
-      BKTEvaluationDetails(
+    assertEvaluationDetails(
+      actual = BKTClient.getInstance().objectVariationDetails(FEATURE_ID_DOUBLE, defaultValue = BKTValue.Number(1.0)),
+      expected = BKTEvaluationDetails(
         featureId = FEATURE_ID_DOUBLE,
         featureVersion = 3,
         userId = USER_ID,
@@ -275,10 +268,9 @@ class BKTClientVariationTest {
       ),
     )
 
-    assertThat(
-      BKTClient.getInstance().boolVariationDetails(FEATURE_ID_BOOLEAN, defaultValue = true),
-    ).isEqualTo(
-      BKTEvaluationDetails(
+    assertEvaluationDetails(
+      actual = BKTClient.getInstance().boolVariationDetails(FEATURE_ID_BOOLEAN, defaultValue = true),
+      expected = BKTEvaluationDetails(
         featureId = FEATURE_ID_BOOLEAN,
         featureVersion = 3,
         userId = USER_ID,
@@ -289,10 +281,9 @@ class BKTClientVariationTest {
       ),
     )
 
-    assertThat(
-      BKTClient.getInstance().objectVariationDetails(FEATURE_ID_BOOLEAN, defaultValue = BKTValue.Number(1.0)),
-    ).isEqualTo(
-      BKTEvaluationDetails(
+    assertEvaluationDetails(
+      actual = BKTClient.getInstance().objectVariationDetails(FEATURE_ID_BOOLEAN, defaultValue = BKTValue.Number(1.0)),
+      expected = BKTEvaluationDetails(
         featureId = FEATURE_ID_BOOLEAN,
         featureVersion = 3,
         userId = USER_ID,
@@ -333,8 +324,8 @@ class BKTClientVariationTest {
   fun objectVariation_detail() {
     val actual = BKTClient.getInstance().evaluationDetails(FEATURE_ID_JSON)
     assertEvaluation(
-      actual,
-      BKTEvaluation(
+      actual = actual,
+      expected = BKTEvaluation(
         id = "feature-android-e2e-json:3:bucketeer-android-user-id-1",
         featureId = FEATURE_ID_JSON,
         featureVersion = 3,
@@ -359,10 +350,9 @@ class BKTClientVariationTest {
             ),
         )
 
-    assertThat(
-      actualEvaluationDetails,
-    ).isEqualTo(
-      BKTEvaluationDetails(
+    assertEvaluationDetails(
+      actual = actualEvaluationDetails,
+      expected = BKTEvaluationDetails(
         featureId = FEATURE_ID_JSON,
         featureVersion = 3,
         userId = USER_ID,

--- a/bucketeer/src/androidTest/kotlin/io/bucketeer/sdk/android/e2e/BKTClientVariationTest.kt
+++ b/bucketeer/src/androidTest/kotlin/io/bucketeer/sdk/android/e2e/BKTClientVariationTest.kt
@@ -93,28 +93,30 @@ class BKTClientVariationTest {
 
     assertEvaluationDetails(
       actual = BKTClient.getInstance().stringVariationDetails(FEATURE_ID_STRING, defaultValue = "1"),
-      expected = BKTEvaluationDetails(
-        featureId = FEATURE_ID_STRING,
-        featureVersion = 4,
-        userId = USER_ID,
-        variationId = "36a53a17-60b4-4a99-a54a-7fcbf21f7c8c",
-        variationName = "variation 1",
-        variationValue = "value-1",
-        reason = BKTEvaluationDetails.Reason.DEFAULT,
-      ),
+      expected =
+        BKTEvaluationDetails(
+          featureId = FEATURE_ID_STRING,
+          featureVersion = 4,
+          userId = USER_ID,
+          variationId = "36a53a17-60b4-4a99-a54a-7fcbf21f7c8c",
+          variationName = "variation 1",
+          variationValue = "value-1",
+          reason = BKTEvaluationDetails.Reason.DEFAULT,
+        ),
     )
 
     assertEvaluationDetails(
       actual = BKTClient.getInstance().objectVariationDetails(FEATURE_ID_STRING, defaultValue = BKTValue.String("1")),
-      expected = BKTEvaluationDetails(
-        featureId = FEATURE_ID_STRING,
-        featureVersion = 4,
-        userId = USER_ID,
-        variationId = "36a53a17-60b4-4a99-a54a-7fcbf21f7c8c",
-        variationName = "variation 1",
-        variationValue = BKTValue.String("value-1"),
-        reason = BKTEvaluationDetails.Reason.DEFAULT,
-      ),
+      expected =
+        BKTEvaluationDetails(
+          featureId = FEATURE_ID_STRING,
+          featureVersion = 4,
+          userId = USER_ID,
+          variationId = "36a53a17-60b4-4a99-a54a-7fcbf21f7c8c",
+          variationName = "variation 1",
+          variationValue = BKTValue.String("value-1"),
+          reason = BKTEvaluationDetails.Reason.DEFAULT,
+        ),
     )
   }
 
@@ -146,28 +148,30 @@ class BKTClientVariationTest {
 
     assertEvaluationDetails(
       actual = BKTClient.getInstance().intVariationDetails(FEATURE_ID_INT, defaultValue = 1),
-      expected = BKTEvaluationDetails(
-        featureId = FEATURE_ID_INT,
-        featureVersion = 3,
-        userId = USER_ID,
-        variationId = "9b9a4396-d2ec-4eaf-aee6-ca0276881120",
-        variationName = "variation 10",
-        variationValue = 10,
-        reason = BKTEvaluationDetails.Reason.DEFAULT,
-      ),
+      expected =
+        BKTEvaluationDetails(
+          featureId = FEATURE_ID_INT,
+          featureVersion = 3,
+          userId = USER_ID,
+          variationId = "9b9a4396-d2ec-4eaf-aee6-ca0276881120",
+          variationName = "variation 10",
+          variationValue = 10,
+          reason = BKTEvaluationDetails.Reason.DEFAULT,
+        ),
     )
 
     assertEvaluationDetails(
       actual = BKTClient.getInstance().objectVariationDetails(FEATURE_ID_INT, defaultValue = BKTValue.Number(1.0)),
-      expected = BKTEvaluationDetails(
-        featureId = FEATURE_ID_INT,
-        featureVersion = 3,
-        userId = USER_ID,
-        variationId = "9b9a4396-d2ec-4eaf-aee6-ca0276881120",
-        variationName = "variation 10",
-        variationValue = BKTValue.Number(10.0),
-        reason = BKTEvaluationDetails.Reason.DEFAULT,
-      ),
+      expected =
+        BKTEvaluationDetails(
+          featureId = FEATURE_ID_INT,
+          featureVersion = 3,
+          userId = USER_ID,
+          variationId = "9b9a4396-d2ec-4eaf-aee6-ca0276881120",
+          variationName = "variation 10",
+          variationValue = BKTValue.Number(10.0),
+          reason = BKTEvaluationDetails.Reason.DEFAULT,
+        ),
     )
   }
 
@@ -190,55 +194,59 @@ class BKTClientVariationTest {
     val actual = BKTClient.getInstance().evaluationDetails(FEATURE_ID_DOUBLE)
     assertEvaluation(
       actual = actual,
-      expected = BKTEvaluation(
-        id = "feature-android-e2e-double:3:bucketeer-android-user-id-1",
-        featureId = FEATURE_ID_DOUBLE,
-        featureVersion = 3,
-        userId = USER_ID,
-        variationId = "384bbcf0-0d1d-4e7a-b589-850f16f833b4",
-        variationName = "variation 2.1",
-        variationValue = "2.1",
-        reason = BKTEvaluation.Reason.DEFAULT,
-      ),
+      expected =
+        BKTEvaluation(
+          id = "feature-android-e2e-double:3:bucketeer-android-user-id-1",
+          featureId = FEATURE_ID_DOUBLE,
+          featureVersion = 3,
+          userId = USER_ID,
+          variationId = "384bbcf0-0d1d-4e7a-b589-850f16f833b4",
+          variationName = "variation 2.1",
+          variationValue = "2.1",
+          reason = BKTEvaluation.Reason.DEFAULT,
+        ),
     )
 
     assertEvaluationDetails(
       actual = BKTClient.getInstance().doubleVariationDetails(FEATURE_ID_DOUBLE, defaultValue = 3.4),
-      expected = BKTEvaluationDetails(
-        featureId = FEATURE_ID_DOUBLE,
-        featureVersion = 3,
-        userId = USER_ID,
-        variationId = "384bbcf0-0d1d-4e7a-b589-850f16f833b4",
-        variationName = "variation 2.1",
-        variationValue = 2.1,
-        reason = BKTEvaluationDetails.Reason.DEFAULT,
-      ),
+      expected =
+        BKTEvaluationDetails(
+          featureId = FEATURE_ID_DOUBLE,
+          featureVersion = 3,
+          userId = USER_ID,
+          variationId = "384bbcf0-0d1d-4e7a-b589-850f16f833b4",
+          variationName = "variation 2.1",
+          variationValue = 2.1,
+          reason = BKTEvaluationDetails.Reason.DEFAULT,
+        ),
     )
 
     assertEvaluationDetails(
       actual = BKTClient.getInstance().intVariationDetails(FEATURE_ID_DOUBLE, defaultValue = 44),
-      expected = BKTEvaluationDetails(
-        featureId = FEATURE_ID_DOUBLE,
-        featureVersion = 3,
-        userId = USER_ID,
-        variationId = "384bbcf0-0d1d-4e7a-b589-850f16f833b4",
-        variationName = "variation 2.1",
-        variationValue = 2,
-        reason = BKTEvaluationDetails.Reason.DEFAULT,
-      ),
+      expected =
+        BKTEvaluationDetails(
+          featureId = FEATURE_ID_DOUBLE,
+          featureVersion = 3,
+          userId = USER_ID,
+          variationId = "384bbcf0-0d1d-4e7a-b589-850f16f833b4",
+          variationName = "variation 2.1",
+          variationValue = 2,
+          reason = BKTEvaluationDetails.Reason.DEFAULT,
+        ),
     )
 
     assertEvaluationDetails(
       actual = BKTClient.getInstance().objectVariationDetails(FEATURE_ID_DOUBLE, defaultValue = BKTValue.Number(1.0)),
-      expected = BKTEvaluationDetails(
-        featureId = FEATURE_ID_DOUBLE,
-        featureVersion = 3,
-        userId = USER_ID,
-        variationId = "384bbcf0-0d1d-4e7a-b589-850f16f833b4",
-        variationName = "variation 2.1",
-        variationValue = BKTValue.Number(2.1),
-        reason = BKTEvaluationDetails.Reason.DEFAULT,
-      ),
+      expected =
+        BKTEvaluationDetails(
+          featureId = FEATURE_ID_DOUBLE,
+          featureVersion = 3,
+          userId = USER_ID,
+          variationId = "384bbcf0-0d1d-4e7a-b589-850f16f833b4",
+          variationName = "variation 2.1",
+          variationValue = BKTValue.Number(2.1),
+          reason = BKTEvaluationDetails.Reason.DEFAULT,
+        ),
     )
   }
 
@@ -270,28 +278,30 @@ class BKTClientVariationTest {
 
     assertEvaluationDetails(
       actual = BKTClient.getInstance().boolVariationDetails(FEATURE_ID_BOOLEAN, defaultValue = true),
-      expected = BKTEvaluationDetails(
-        featureId = FEATURE_ID_BOOLEAN,
-        featureVersion = 3,
-        userId = USER_ID,
-        variationId = "774fb34d-5b08-4305-9995-08cdac47aa0f",
-        variationName = "variation true",
-        variationValue = true,
-        reason = BKTEvaluationDetails.Reason.DEFAULT,
-      ),
+      expected =
+        BKTEvaluationDetails(
+          featureId = FEATURE_ID_BOOLEAN,
+          featureVersion = 3,
+          userId = USER_ID,
+          variationId = "774fb34d-5b08-4305-9995-08cdac47aa0f",
+          variationName = "variation true",
+          variationValue = true,
+          reason = BKTEvaluationDetails.Reason.DEFAULT,
+        ),
     )
 
     assertEvaluationDetails(
       actual = BKTClient.getInstance().objectVariationDetails(FEATURE_ID_BOOLEAN, defaultValue = BKTValue.Number(1.0)),
-      expected = BKTEvaluationDetails(
-        featureId = FEATURE_ID_BOOLEAN,
-        featureVersion = 3,
-        userId = USER_ID,
-        variationId = "774fb34d-5b08-4305-9995-08cdac47aa0f",
-        variationName = "variation true",
-        variationValue = BKTValue.Boolean(true),
-        reason = BKTEvaluationDetails.Reason.DEFAULT,
-      ),
+      expected =
+        BKTEvaluationDetails(
+          featureId = FEATURE_ID_BOOLEAN,
+          featureVersion = 3,
+          userId = USER_ID,
+          variationId = "774fb34d-5b08-4305-9995-08cdac47aa0f",
+          variationName = "variation true",
+          variationValue = BKTValue.Boolean(true),
+          reason = BKTEvaluationDetails.Reason.DEFAULT,
+        ),
     )
   }
 
@@ -325,16 +335,17 @@ class BKTClientVariationTest {
     val actual = BKTClient.getInstance().evaluationDetails(FEATURE_ID_JSON)
     assertEvaluation(
       actual = actual,
-      expected = BKTEvaluation(
-        id = "feature-android-e2e-json:3:bucketeer-android-user-id-1",
-        featureId = FEATURE_ID_JSON,
-        featureVersion = 3,
-        userId = USER_ID,
-        variationId = "4499d1ca-411d-4ec6-9ae8-df51087e72bb",
-        variationName = "variation 1",
-        variationValue = """{ "key": "value-1" }""",
-        reason = BKTEvaluation.Reason.DEFAULT,
-      ),
+      expected =
+        BKTEvaluation(
+          id = "feature-android-e2e-json:3:bucketeer-android-user-id-1",
+          featureId = FEATURE_ID_JSON,
+          featureVersion = 3,
+          userId = USER_ID,
+          variationId = "4499d1ca-411d-4ec6-9ae8-df51087e72bb",
+          variationName = "variation 1",
+          variationValue = """{ "key": "value-1" }""",
+          reason = BKTEvaluation.Reason.DEFAULT,
+        ),
     )
 
     val actualEvaluationDetails =
@@ -352,20 +363,21 @@ class BKTClientVariationTest {
 
     assertEvaluationDetails(
       actual = actualEvaluationDetails,
-      expected = BKTEvaluationDetails(
-        featureId = FEATURE_ID_JSON,
-        featureVersion = 3,
-        userId = USER_ID,
-        variationId = "4499d1ca-411d-4ec6-9ae8-df51087e72bb",
-        variationName = "variation 1",
-        variationValue =
-          BKTValue.Structure(
-            mapOf(
-              "key" to BKTValue.String("value-1"),
+      expected =
+        BKTEvaluationDetails(
+          featureId = FEATURE_ID_JSON,
+          featureVersion = 3,
+          userId = USER_ID,
+          variationId = "4499d1ca-411d-4ec6-9ae8-df51087e72bb",
+          variationName = "variation 1",
+          variationValue =
+            BKTValue.Structure(
+              mapOf(
+                "key" to BKTValue.String("value-1"),
+              ),
             ),
-          ),
-        reason = BKTEvaluationDetails.Reason.DEFAULT,
-      ),
+          reason = BKTEvaluationDetails.Reason.DEFAULT,
+        ),
     )
   }
 }

--- a/bucketeer/src/androidTest/kotlin/io/bucketeer/sdk/android/e2e/TestHelpers.kt
+++ b/bucketeer/src/androidTest/kotlin/io/bucketeer/sdk/android/e2e/TestHelpers.kt
@@ -2,6 +2,7 @@ package io.bucketeer.sdk.android.e2e
 
 import com.google.common.truth.Truth.assertThat
 import io.bucketeer.sdk.android.BKTEvaluation
+import io.bucketeer.sdk.android.BKTEvaluationDetails
 
 fun assertEvaluation(
   actual: BKTEvaluation?,
@@ -13,6 +14,19 @@ fun assertEvaluation(
   assertThat(actual.featureVersion).isEqualTo(expected.featureVersion)
   assertThat(actual.userId).isEqualTo(expected.userId)
   assertThat(actual.variationId).isEqualTo(expected.variationId)
+  assertThat(actual.variationValue).isEqualTo(expected.variationValue)
+  assertThat(actual.reason).isEqualTo(expected.reason)
+}
+
+fun <T>assertEvaluationDetails(
+  actual: BKTEvaluationDetails<T>,
+  expected: BKTEvaluationDetails<T>,
+) {
+  //Skipped check featureVersion
+  assertThat(actual.featureId).isEqualTo(expected.featureId)
+  assertThat(actual.userId).isEqualTo(expected.userId)
+  assertThat(actual.variationId).isEqualTo(expected.variationId)
+  assertThat(actual.variationName).isEqualTo(expected.variationName)
   assertThat(actual.variationValue).isEqualTo(expected.variationValue)
   assertThat(actual.reason).isEqualTo(expected.reason)
 }

--- a/bucketeer/src/androidTest/kotlin/io/bucketeer/sdk/android/e2e/TestHelpers.kt
+++ b/bucketeer/src/androidTest/kotlin/io/bucketeer/sdk/android/e2e/TestHelpers.kt
@@ -18,11 +18,11 @@ fun assertEvaluation(
   assertThat(actual.reason).isEqualTo(expected.reason)
 }
 
-fun <T>assertEvaluationDetails(
+fun <T> assertEvaluationDetails(
   actual: BKTEvaluationDetails<T>,
   expected: BKTEvaluationDetails<T>,
 ) {
-  //Skipped check featureVersion
+  // Skipped check featureVersion
   assertThat(actual.featureId).isEqualTo(expected.featureId)
   assertThat(actual.userId).isEqualTo(expected.userId)
   assertThat(actual.variationId).isEqualTo(expected.variationId)


### PR DESCRIPTION
This pull request addresses an issue with end-to-end test failures and skips checks on the featureVersion.