### PR TITLE
ci: improve e2e test runner performance

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,6 +1,7 @@
 name: e2e
 
 on:
+  pull_request:
   workflow_dispatch:
   workflow_call:
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,7 +1,6 @@
 name: e2e
 
 on:
-  pull_request:
   workflow_dispatch:
   workflow_call:
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   e2e:
     # macos-13-xlarge is an M1 mac (which has no Android SDK)
-    runs-on: macos-14-large
+    runs-on: ubuntu-latest
     timeout-minutes: 45
     strategy:
       matrix:
@@ -36,6 +36,12 @@ jobs:
             ~/.android/avd/*
             ~/.android/adb*
           key: avd-${{ matrix.api-level }}
+
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
 
       - name: Create AVD and generate snapshot for caching
         if: steps.avd-cache.outputs.cache-hit != 'true'

--- a/sample/src/google-services.json
+++ b/sample/src/google-services.json
@@ -1,13 +1,13 @@
 {
   "project_info": {
-    "project_number": "1",
-    "project_id": "bucketeer-dev",
-    "storage_bucket": "bucketeer-dev.appspot.com"
+    "project_number": "733448580849",
+    "project_id": "bucketeer-dev-cd29c",
+    "storage_bucket": "bucketeer-dev-cd29c.firebasestorage.app"
   },
   "client": [
     {
       "client_info": {
-        "mobilesdk_app_id": "1:733448580849:android:3c",
+        "mobilesdk_app_id": "1:733448580849:android:3c0fd5d3aaa084b4ce8350",
         "android_client_info": {
           "package_name": "io.bucketeer.sample"
         }
@@ -15,7 +15,26 @@
       "oauth_client": [],
       "api_key": [
         {
-          "current_key": "AIzaSyDLZ"
+          "current_key": "AIzaSyDLZT2pEbvVCQTaqaFFLvf3EwiO_rdT74M"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": []
+        }
+      }
+    },
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:733448580849:android:e6840738e94053eece8350",
+        "android_client_info": {
+          "package_name": "jp.bucketeer.sample"
+        }
+      },
+      "oauth_client": [],
+      "api_key": [
+        {
+          "current_key": "AIzaSyDLZT2pEbvVCQTaqaFFLvf3EwiO_rdT74M"
         }
       ],
       "services": {


### PR DESCRIPTION
I found some issues when using the Android SDK as the reference for building the OpenFeature Kotlin Provider.

This pull request includes several CI/CD workflow changes and configuration files. The most important changes involve updating the environment for end-to-end (e2e) tests and modifying the `google-services.json` file

Changes:
- [x] Use `ubuntu-latest` and add a step to enable KVM (Kernel-based Virtual Machine) for better performance during Android emulation. (Reduce the e2e test from 25 minutes to 6 minutes)
   - Before (25 mins): https://github.com/bucketeer-io/android-client-sdk/actions/runs/13896653761 
   - After (6 mins): https://github.com/bucketeer-io/android-client-sdk/actions/runs/13899026054/job/38886143953?pr=218
- [x] Fix build Android example app fail because invalid clientId in the file `google-service.json` 
