### PR TITLE
fix: prevent logger leaks when destroying and not working when building the client

### DIFF
--- a/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/BKTClient.kt
+++ b/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/BKTClient.kt
@@ -132,6 +132,7 @@ interface BKTClient {
           clientImpl.destroy()
         }
         instance = null
+        LoggerHolder.clearLoggers()
       }
     }
   }

--- a/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/BKTConfig.kt
+++ b/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/BKTConfig.kt
@@ -1,6 +1,6 @@
 package io.bucketeer.sdk.android
 
-import io.bucketeer.sdk.android.internal.logw
+import android.util.Log
 import io.bucketeer.sdk.android.internal.util.require
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 
@@ -12,6 +12,8 @@ internal const val DEFAULT_POLLING_INTERVAL_MILLIS: Long = 600_000 // 10 minutes
 internal const val MINIMUM_BACKGROUND_POLLING_INTERVAL_MILLIS: Long = 1_200_000 // 20 minutes
 internal const val DEFAULT_BACKGROUND_POLLING_INTERVAL_MILLIS: Long = 3_600_000 // 1 hour
 
+// hide internal constructor from copy() method
+@ConsistentCopyVisibility
 data class BKTConfig internal constructor(
   val apiKey: String,
   val apiEndpoint: String,
@@ -83,18 +85,27 @@ data class BKTConfig internal constructor(
       return this
     }
 
+    private fun logWarning(messageCreator: (() -> String?)? = null) {
+      // LoggerHolder.log() is not available here, so we use the logger directly.
+      logger?.log(
+        Log.WARN,
+        messageCreator,
+        null,
+      )
+    }
+
     fun build(): BKTConfig {
       require(!this.apiKey.isNullOrEmpty()) { "apiKey is required" }
       require(this.apiEndpoint?.toHttpUrlOrNull() != null) { "apiEndpoint is invalid" }
       require(!this.appVersion.isNullOrEmpty()) { "appVersion is required" }
 
       if (this.pollingInterval < MINIMUM_POLLING_INTERVAL_MILLIS) {
-        logw { "pollingInterval: $pollingInterval is set but must be above $MINIMUM_POLLING_INTERVAL_MILLIS" }
+        logWarning { "pollingInterval: $pollingInterval is set but must be above $MINIMUM_POLLING_INTERVAL_MILLIS" }
         this.pollingInterval = MINIMUM_POLLING_INTERVAL_MILLIS
       }
 
       if (this.backgroundPollingInterval < MINIMUM_BACKGROUND_POLLING_INTERVAL_MILLIS) {
-        logw {
+        logWarning {
           "backgroundPollingInterval: $backgroundPollingInterval is set but must be above " +
             "$MINIMUM_BACKGROUND_POLLING_INTERVAL_MILLIS"
         }
@@ -102,7 +113,7 @@ data class BKTConfig internal constructor(
       }
 
       if (this.eventsFlushInterval < MINIMUM_FLUSH_INTERVAL_MILLIS) {
-        logw { "eventsFlushInterval: $eventsFlushInterval is set but must be above $MINIMUM_FLUSH_INTERVAL_MILLIS" }
+        logWarning { "eventsFlushInterval: $eventsFlushInterval is set but must be above $MINIMUM_FLUSH_INTERVAL_MILLIS" }
         this.eventsFlushInterval = DEFAULT_FLUSH_INTERVAL_MILLIS
       }
 

--- a/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/logger.kt
+++ b/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/logger.kt
@@ -25,6 +25,12 @@ internal object LoggerHolder {
       }
     }
   }
+
+  fun clearLoggers() {
+    synchronized(logHandlers) {
+      logHandlers.clear()
+    }
+  }
 }
 
 // TODO: Add msgCreator log methods

--- a/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/BKTConfigTest.kt
+++ b/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/BKTConfigTest.kt
@@ -3,7 +3,10 @@ package io.bucketeer.sdk.android
 import com.google.common.truth.Truth.assertThat
 import org.junit.Assert.assertThrows
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
 
+@RunWith(RobolectricTestRunner::class)
 class BKTConfigTest {
   @Test
   fun build() {

--- a/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/LoggerHolderTest.kt
+++ b/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/LoggerHolderTest.kt
@@ -44,6 +44,7 @@ internal class LoggerHolderTest {
             try {
               logd { "Test message" }
               LoggerHolder.addLogger(TestLogger())
+              LoggerHolder.clearLoggers()
               LoggerHolder.addLogger(TestLogger())
             } catch (e: ConcurrentModificationException) {
               fail("ConcurrentModificationException occurred")


### PR DESCRIPTION
## Bug Fixes
- Fixed a potential memory leak in LoggerHolder, which wasn't cleared when the client was destroyed.
- Fixed an issue where logs didn't work when building BKTConfig, due to LoggerHolder not being initialized at that time.