### PR TITLE
fix: userAttributesUpdated being sent as string not a boolean

### DIFF
--- a/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/evaluation/EvaluationInteractor.kt
+++ b/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/evaluation/EvaluationInteractor.kt
@@ -60,7 +60,7 @@ internal class EvaluationInteractor(
   ): GetEvaluationsResult {
     val currentEvaluationsId = evaluationStorage.getCurrentEvaluationId()
     val evaluatedAt = evaluationStorage.getEvaluatedAt()
-    val userAttributesUpdated = evaluationStorage.getUserAttributesUpdated().toString()
+    val userAttributesUpdated = evaluationStorage.getUserAttributesUpdated()
 
     val condition =
       UserEvaluationCondition(

--- a/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/remote/UserEvaluationCondition.kt
+++ b/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/remote/UserEvaluationCondition.kt
@@ -5,5 +5,5 @@ import com.squareup.moshi.JsonClass
 @JsonClass(generateAdapter = true)
 data class UserEvaluationCondition(
   val evaluatedAt: String,
-  val userAttributesUpdated: String,
+  val userAttributesUpdated: Boolean,
 )

--- a/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/internal/evaluation/EvaluationInteractorTest.kt
+++ b/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/internal/evaluation/EvaluationInteractorTest.kt
@@ -244,7 +244,7 @@ class EvaluationInteractorTest {
     assertThat(firstRequestBody!!.userEvaluationCondition).isEqualTo(
       UserEvaluationCondition(
         evaluatedAt = "10000",
-        userAttributesUpdated = "false",
+        userAttributesUpdated = false,
       ),
     )
 
@@ -260,7 +260,7 @@ class EvaluationInteractorTest {
     assertThat(secondRequestBody!!.userEvaluationCondition).isEqualTo(
       UserEvaluationCondition(
         evaluatedAt = "1690798021",
-        userAttributesUpdated = "true",
+        userAttributesUpdated = true,
       ),
     )
 
@@ -310,7 +310,7 @@ class EvaluationInteractorTest {
     assertThat(requestBody.userEvaluationCondition).isEqualTo(
       UserEvaluationCondition(
         evaluatedAt = "0",
-        userAttributesUpdated = "true",
+        userAttributesUpdated = true,
       ),
     )
 

--- a/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/internal/remote/ApiClientImplTest.kt
+++ b/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/internal/remote/ApiClientImplTest.kt
@@ -139,7 +139,7 @@ internal class ApiClientImplTest {
         condition =
           UserEvaluationCondition(
             evaluatedAt = "1690798100",
-            userAttributesUpdated = "true",
+            userAttributesUpdated = true,
           ),
       )
 
@@ -161,7 +161,7 @@ internal class ApiClientImplTest {
         userEvaluationCondition =
           UserEvaluationCondition(
             evaluatedAt = "1690798100",
-            userAttributesUpdated = "true",
+            userAttributesUpdated = true,
           ),
         sdkVersion = BuildConfig.SDK_VERSION,
       ),
@@ -195,7 +195,7 @@ internal class ApiClientImplTest {
           condition =
             UserEvaluationCondition(
               evaluatedAt = "1690798200",
-              userAttributesUpdated = "false",
+              userAttributesUpdated = false,
             ),
         )
       }
@@ -230,7 +230,7 @@ internal class ApiClientImplTest {
           condition =
             UserEvaluationCondition(
               evaluatedAt = "1690798200",
-              userAttributesUpdated = "false",
+              userAttributesUpdated = false,
             ),
         )
       }
@@ -264,7 +264,7 @@ internal class ApiClientImplTest {
         condition =
           UserEvaluationCondition(
             evaluatedAt = "1690798200",
-            userAttributesUpdated = "false",
+            userAttributesUpdated = false,
           ),
       )
 
@@ -310,7 +310,7 @@ internal class ApiClientImplTest {
         condition =
           UserEvaluationCondition(
             evaluatedAt = "1690799200",
-            userAttributesUpdated = "true",
+            userAttributesUpdated = true,
           ),
       )
 
@@ -352,7 +352,7 @@ internal class ApiClientImplTest {
         condition =
           UserEvaluationCondition(
             evaluatedAt = "1690799200",
-            userAttributesUpdated = "true",
+            userAttributesUpdated = true,
           ),
       )
 
@@ -577,7 +577,7 @@ internal class ApiClientImplTest {
         condition =
           UserEvaluationCondition(
             evaluatedAt = "1690798100",
-            userAttributesUpdated = "true",
+            userAttributesUpdated = true,
           ),
       )
 


### PR DESCRIPTION
This pull request updates the UserEvaluationCondition model by changing the type of the `userAttributesUpdated` field from `String` to `Boolean`.
Using a String previously caused the request to [fail](https://github.com/bucketeer-io/android-client-sdk/actions/runs/15337390704) after the backend changed how it parses the request.

Test E2e now [passed](https://github.com/bucketeer-io/android-client-sdk/actions/runs/15338842511) 