### PR TITLE
fix: wrapperSdkVersion is required when setting wrapperSdkSourceId.

### DIFF
--- a/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/BKTConfig.kt
+++ b/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/BKTConfig.kt
@@ -193,10 +193,13 @@ internal fun resolveSdkVersion(
   wrapperSdkVersion: String?,
 ): String =
   if (sourceId != SourceId.ANDROID) {
-    if (!wrapperSdkVersion.isNullOrBlank()) wrapperSdkVersion
-    else throw BKTException.IllegalArgumentException(
-      "wrapperSdkVersion is required when sourceId is not ANDROID",
-    )
+    if (!wrapperSdkVersion.isNullOrBlank()) {
+      wrapperSdkVersion
+    } else {
+      throw BKTException.IllegalArgumentException(
+        "wrapperSdkVersion is required when sourceId is not ANDROID",
+      )
+    }
   } else {
     BuildConfig.SDK_VERSION
   }

--- a/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/BKTConfig.kt
+++ b/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/BKTConfig.kt
@@ -147,8 +147,12 @@ data class BKTConfig internal constructor(
         this.eventsFlushInterval = DEFAULT_FLUSH_INTERVAL_MILLIS
       }
 
-      val resolvedSourceId = resolveSdkSourceId(this.wrapperSdkSourceId)
-      val resolvedSdkVersion = resolveSdkVersion(resolvedSourceId, wrapperSdkVersion)
+      val resolvedSourceId = resolveSdkSourceId(wrapperSdkSourceIdValue = this.wrapperSdkSourceId)
+      val resolvedSdkVersion =
+        resolveSdkVersion(
+          resolvedSourceId = resolvedSourceId,
+          wrapperSdkVersion = wrapperSdkVersion,
+        )
 
       return BKTConfig(
         apiKey = this.apiKey!!,
@@ -168,11 +172,11 @@ data class BKTConfig internal constructor(
 }
 
 @VisibleForTesting
-internal fun resolveSdkSourceId(wrapperSdkSourceIdNumber: Int?): SourceId {
-  if (wrapperSdkSourceIdNumber == null) {
+internal fun resolveSdkSourceId(wrapperSdkSourceIdValue: Int?): SourceId {
+  if (wrapperSdkSourceIdValue == null) {
     return SourceId.ANDROID
   }
-  val wrapperSdkSourceId = SourceId.from(wrapperSdkSourceIdNumber)
+  val wrapperSdkSourceId = SourceId.from(wrapperSdkSourceIdValue)
   val availableWrapperSDKs =
     setOf(
       SourceId.FLUTTER,
@@ -189,10 +193,10 @@ internal fun resolveSdkSourceId(wrapperSdkSourceIdNumber: Int?): SourceId {
 
 @VisibleForTesting
 internal fun resolveSdkVersion(
-  sourceId: SourceId,
+  resolvedSourceId: SourceId,
   wrapperSdkVersion: String?,
 ): String =
-  if (sourceId != SourceId.ANDROID) {
+  if (resolvedSourceId != SourceId.ANDROID) {
     if (!wrapperSdkVersion.isNullOrBlank()) {
       wrapperSdkVersion
     } else {

--- a/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/BKTConfig.kt
+++ b/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/BKTConfig.kt
@@ -26,7 +26,7 @@ data class BKTConfig internal constructor(
   val backgroundPollingInterval: Long,
   val appVersion: String,
   val logger: BKTLogger?,
-  val sourceIdNumber: Int,
+  val sourceIdValue: Int,
   val sdkVersion: String,
 ) {
   companion object {
@@ -34,7 +34,7 @@ data class BKTConfig internal constructor(
   }
 
   // SourceID is internal and its not exposed to the public API.
-  internal val sourceId: SourceId = SourceId.from(sourceIdNumber)
+  internal val sourceId: SourceId = SourceId.from(sourceIdValue)
 
   class Builder internal constructor() {
     private var apiKey: String? = null
@@ -148,7 +148,7 @@ data class BKTConfig internal constructor(
       }
 
       val resolvedSourceId = resolveSdkSourceId(this.wrapperSdkSourceId)
-      val sdkVersion = resolveSdkVersion(resolvedSourceId, wrapperSdkVersion)
+      val resolvedSdkVersion = resolveSdkVersion(resolvedSourceId, wrapperSdkVersion)
 
       return BKTConfig(
         apiKey = this.apiKey!!,
@@ -160,8 +160,8 @@ data class BKTConfig internal constructor(
         backgroundPollingInterval = this.backgroundPollingInterval,
         appVersion = this.appVersion!!,
         logger = this.logger,
-        sourceIdNumber = resolvedSourceId.value,
-        sdkVersion = sdkVersion,
+        sourceIdValue = resolvedSourceId.value,
+        sdkVersion = resolvedSdkVersion,
       )
     }
   }

--- a/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/BKTConfigTest.kt
+++ b/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/BKTConfigTest.kt
@@ -372,7 +372,6 @@ class BKTConfigTest {
     }
   }
 
-  // Test cases for resolveSourceIdAnd resolveSdkVersion function here
   @Test
   fun `resolveSdkSourceId - null returns ANDROID`() {
     val result = resolveSdkSourceId(null)

--- a/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/BKTConfigTest.kt
+++ b/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/BKTConfigTest.kt
@@ -392,12 +392,18 @@ class BKTConfigTest {
 
   @Test
   fun `resolveSdkSourceId - unsupported sourceId throws exception`() {
-    val error =
-      assertThrows(BKTException.IllegalArgumentException::class.java) {
-        // Using an unsupported SourceId
-        resolveSdkSourceId(SourceId.IOS.value)
+    val listSourceIds =
+      SourceId.entries.filter {
+        it != SourceId.FLUTTER && it != SourceId.OPEN_FEATURE_KOTLIN
       }
-    assertThat(error).hasMessageThat().contains("Unsupported wrapperSdkSourceId")
+    for (si in listSourceIds) {
+      val error =
+        assertThrows(BKTException.IllegalArgumentException::class.java) {
+          // Using an unsupported SourceId
+          resolveSdkSourceId(si.value)
+        }
+      assertThat(error).hasMessageThat().contains("Unsupported wrapperSdkSourceId")
+    }
   }
 
   @Test
@@ -418,7 +424,8 @@ class BKTConfigTest {
       assertThrows(BKTException.IllegalArgumentException::class.java) {
         resolveSdkVersion(SourceId.FLUTTER, "")
       }
-    assertThat(error).hasMessageThat().contains("wrapperSdkVersion is required when sourceId is not ANDROID")
+    assertThat(error).hasMessageThat()
+      .contains("wrapperSdkVersion is required when sourceId is not ANDROID")
   }
 
   @Test
@@ -427,6 +434,7 @@ class BKTConfigTest {
       assertThrows(BKTException.IllegalArgumentException::class.java) {
         resolveSdkVersion(SourceId.FLUTTER, null)
       }
-    assertThat(error).hasMessageThat().contains("wrapperSdkVersion is required when sourceId is not ANDROID")
+    assertThat(error).hasMessageThat()
+      .contains("wrapperSdkVersion is required when sourceId is not ANDROID")
   }
 }

--- a/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/BKTConfigTest.kt
+++ b/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/BKTConfigTest.kt
@@ -30,7 +30,7 @@ class BKTConfigTest {
         backgroundPollingInterval = DEFAULT_BACKGROUND_POLLING_INTERVAL_MILLIS,
         appVersion = "1.2.3",
         logger = DefaultLogger("Bucketeer"),
-        sourceIdNumber = SourceId.ANDROID.value,
+        sourceIdValue = SourceId.ANDROID.value,
         sdkVersion = BuildConfig.SDK_VERSION,
       )
     assertThat(actual).isEqualTo(
@@ -62,7 +62,7 @@ class BKTConfigTest {
         backgroundPollingInterval = DEFAULT_BACKGROUND_POLLING_INTERVAL_MILLIS,
         appVersion = "1.2.3",
         logger = DefaultLogger("Bucketeer"),
-        sourceIdNumber = SourceId.FLUTTER.value,
+        sourceIdValue = SourceId.FLUTTER.value,
         sdkVersion = "0.0.1-beta-op-ft-kt",
       )
     assertThat(actual).isEqualTo(
@@ -274,7 +274,7 @@ class BKTConfigTest {
         backgroundPollingInterval = DEFAULT_BACKGROUND_POLLING_INTERVAL_MILLIS,
         appVersion = "1.2.3",
         logger = null,
-        sourceIdNumber = SourceId.ANDROID.value,
+        sourceIdValue = SourceId.ANDROID.value,
         sdkVersion = BuildConfig.SDK_VERSION,
       ),
     )
@@ -340,7 +340,7 @@ class BKTConfigTest {
           backgroundPollingInterval = DEFAULT_BACKGROUND_POLLING_INTERVAL_MILLIS,
           appVersion = "1.2.3",
           logger = DefaultLogger("Bucketeer"),
-          sourceIdNumber = sourceId.value,
+          sourceIdValue = sourceId.value,
           sdkVersion = "0.0.1",
         )
       assertThat(actual).isEqualTo(
@@ -403,8 +403,8 @@ class BKTConfigTest {
 
   @Test
   fun `resolveSdkVersion - ANDROID returns BuildConfig version`() {
-    val result = resolveSdkVersion(SourceId.ANDROID, null)
-    assertThat(result).isEqualTo(BuildConfig.SDK_VERSION)
+    assertThat(resolveSdkVersion(SourceId.ANDROID, null)).isEqualTo(BuildConfig.SDK_VERSION)
+    assertThat(resolveSdkVersion(SourceId.ANDROID, "")).isEqualTo(BuildConfig.SDK_VERSION)
   }
 
   @Test

--- a/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/BKTConfigTest.kt
+++ b/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/BKTConfigTest.kt
@@ -2,7 +2,6 @@ package io.bucketeer.sdk.android
 
 import com.google.common.truth.Truth.assertThat
 import io.bucketeer.sdk.android.internal.model.SourceId
-import org.junit.Assert.assertEquals
 import org.junit.Assert.assertThrows
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -31,7 +30,7 @@ class BKTConfigTest {
         backgroundPollingInterval = DEFAULT_BACKGROUND_POLLING_INTERVAL_MILLIS,
         appVersion = "1.2.3",
         logger = DefaultLogger("Bucketeer"),
-        sourceIdValue = SourceId.ANDROID.value,
+        sourceIdNumber = SourceId.ANDROID.value,
         sdkVersion = BuildConfig.SDK_VERSION,
       )
     assertThat(actual).isEqualTo(
@@ -63,7 +62,7 @@ class BKTConfigTest {
         backgroundPollingInterval = DEFAULT_BACKGROUND_POLLING_INTERVAL_MILLIS,
         appVersion = "1.2.3",
         logger = DefaultLogger("Bucketeer"),
-        sourceIdValue = SourceId.FLUTTER.value,
+        sourceIdNumber = SourceId.FLUTTER.value,
         sdkVersion = "0.0.1-beta-op-ft-kt",
       )
     assertThat(actual).isEqualTo(
@@ -275,7 +274,7 @@ class BKTConfigTest {
         backgroundPollingInterval = DEFAULT_BACKGROUND_POLLING_INTERVAL_MILLIS,
         appVersion = "1.2.3",
         logger = null,
-        sourceIdValue = SourceId.ANDROID.value,
+        sourceIdNumber = SourceId.ANDROID.value,
         sdkVersion = BuildConfig.SDK_VERSION,
       ),
     )
@@ -341,7 +340,7 @@ class BKTConfigTest {
           backgroundPollingInterval = DEFAULT_BACKGROUND_POLLING_INTERVAL_MILLIS,
           appVersion = "1.2.3",
           logger = DefaultLogger("Bucketeer"),
-          sourceIdValue = sourceId.value,
+          sourceIdNumber = sourceId.value,
           sdkVersion = "0.0.1",
         )
       assertThat(actual).isEqualTo(
@@ -358,7 +357,7 @@ class BKTConfigTest {
         it != SourceId.FLUTTER && it != SourceId.OPEN_FEATURE_KOTLIN
       }
     for (si in listSourceIds) {
-      val actual =
+      val error = assertThrows(BKTException.IllegalArgumentException::class.java) {
         BKTConfig
           .builder()
           .apiKey("api-key")
@@ -367,76 +366,65 @@ class BKTConfigTest {
           .appVersion("1.2.3")
           .wrapperSdkSourceId(si.value)
           .build()
-      val expected =
-        BKTConfig(
-          apiKey = "api-key",
-          apiEndpoint = "https://example.com",
-          featureTag = "feature-tag",
-          eventsFlushInterval = DEFAULT_FLUSH_INTERVAL_MILLIS,
-          eventsMaxBatchQueueCount = DEFAULT_MAX_QUEUE_SIZE,
-          pollingInterval = DEFAULT_POLLING_INTERVAL_MILLIS,
-          backgroundPollingInterval = DEFAULT_BACKGROUND_POLLING_INTERVAL_MILLIS,
-          appVersion = "1.2.3",
-          logger = DefaultLogger("Bucketeer"),
-          // no error expected
-          // the sourceId will be set to SourceID.ANDROID
-          // and the sdkVersion will be set to BuildConfig.SDK_VERSION
-          sourceIdValue = SourceId.ANDROID.value,
-          sdkVersion = BuildConfig.SDK_VERSION,
-        )
-      assertThat(actual).isEqualTo(
-        expected,
-      )
-      assertThat(actual.sourceId).isEqualTo(SourceId.ANDROID)
+      }
+      assertThat(error).hasMessageThat().contains("Unsupported wrapperSdkSourceId")
     }
   }
 
-  // Test cases for resolveSourceIdAndSdkVersion function
+  // Test cases for resolveSourceIdAnd resolveSdkVersion function here
   @Test
-  fun `resolveSourceIdAndSdkVersion should return ANDROID sourceID and SDK_VERSION when no wrapper SDK is provided`() {
-    val (sourceId, sdkVersion) =
-      resolveSourceIdAndSdkVersion(
-        wrapperSdkSourceId = null,
-        wrapperSdkVersion = null,
-      )
-
-    assertEquals(SourceId.ANDROID, sourceId)
-    assertEquals(BuildConfig.SDK_VERSION, sdkVersion)
+  fun `resolveSdkSourceId - null returns ANDROID`() {
+    val result = resolveSdkSourceId(null)
+    assertThat(result).isEqualTo(SourceId.ANDROID)
   }
 
   @Test
-  fun `resolveSourceIdAndSdkVersion should return provided wrapper SDK sourceID and version`() {
-    val (sourceId, sdkVersion) =
-      resolveSourceIdAndSdkVersion(
-        wrapperSdkSourceId = SourceId.FLUTTER,
-        wrapperSdkVersion = "1.2.3",
-      )
-
-    assertEquals(SourceId.FLUTTER, sourceId)
-    assertEquals("1.2.3", sdkVersion)
+  fun `resolveSdkSourceId - FLUTTER returns FLUTTER`() {
+    val result = resolveSdkSourceId(SourceId.FLUTTER.value)
+    assertThat(result).isEqualTo(SourceId.FLUTTER)
   }
 
   @Test
-  fun `resolveSourceIdAndSdkVersion should return default wrapper SDK version when version is null or blank`() {
-    val (sourceId, sdkVersion) =
-      resolveSourceIdAndSdkVersion(
-        wrapperSdkSourceId = SourceId.FLUTTER,
-        wrapperSdkVersion = null,
-      )
-
-    assertEquals(SourceId.FLUTTER, sourceId)
-    assertEquals(DEFAULT_WRAPPER_SDK_VERSION, sdkVersion)
+  fun `resolveSdkSourceId - OPEN_FEATURE_KOTLIN returns OPEN_FEATURE_KOTLIN`() {
+    val result = resolveSdkSourceId(SourceId.OPEN_FEATURE_KOTLIN.value)
+    assertThat(result).isEqualTo(SourceId.OPEN_FEATURE_KOTLIN)
   }
 
   @Test
-  fun `resolveSourceIdAndSdkVersion should return ANDROID sourceID when an unsupported sourceID is provided`() {
-    val (sourceId, sdkVersion) =
-      resolveSourceIdAndSdkVersion(
-        wrapperSdkSourceId = SourceId.UNKNOWN,
-        wrapperSdkVersion = "1.2.3",
-      )
+  fun `resolveSdkSourceId - unsupported sourceId throws exception`() {
+    val error = assertThrows(BKTException.IllegalArgumentException::class.java) {
+      // Using an unsupported SourceId
+      resolveSdkSourceId(SourceId.IOS.value)
+    }
+    assertThat(error).hasMessageThat().contains("Unsupported wrapperSdkSourceId")
+  }
 
-    assertEquals(SourceId.ANDROID, sourceId)
-    assertEquals(BuildConfig.SDK_VERSION, sdkVersion)
+  @Test
+  fun `resolveSdkVersion - ANDROID returns BuildConfig version`() {
+    val result = resolveSdkVersion(SourceId.ANDROID, null)
+    assertThat(result).isEqualTo(BuildConfig.SDK_VERSION)
+  }
+
+  @Test
+  fun `resolveSdkVersion - non-ANDROID with version returns wrapper version`() {
+    val result = resolveSdkVersion(SourceId.FLUTTER, "1.2.3")
+    assertThat(result).isEqualTo("1.2.3")
+  }
+
+  @Test
+  fun `resolveSdkVersion - non-ANDROID with blank version throws exception`() {
+    val error = assertThrows(BKTException.IllegalArgumentException::class.java) {
+      resolveSdkVersion(SourceId.FLUTTER, "")
+    }
+    assertThat(error).hasMessageThat().contains("wrapperSdkVersion is required when sourceId is not ANDROID")
+  }
+
+  @Test
+  fun `resolveSdkVersion - non-ANDROID with null version throws exception`() {
+    val error = assertThrows(BKTException.IllegalArgumentException::class.java) {
+      resolveSdkVersion(SourceId.FLUTTER, null)
+    }
+    assertThat(error).hasMessageThat().contains("wrapperSdkVersion is required when sourceId is not ANDROID")
   }
 }
+

--- a/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/BKTConfigTest.kt
+++ b/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/BKTConfigTest.kt
@@ -357,16 +357,17 @@ class BKTConfigTest {
         it != SourceId.FLUTTER && it != SourceId.OPEN_FEATURE_KOTLIN
       }
     for (si in listSourceIds) {
-      val error = assertThrows(BKTException.IllegalArgumentException::class.java) {
-        BKTConfig
-          .builder()
-          .apiKey("api-key")
-          .apiEndpoint("https://example.com")
-          .featureTag("feature-tag")
-          .appVersion("1.2.3")
-          .wrapperSdkSourceId(si.value)
-          .build()
-      }
+      val error =
+        assertThrows(BKTException.IllegalArgumentException::class.java) {
+          BKTConfig
+            .builder()
+            .apiKey("api-key")
+            .apiEndpoint("https://example.com")
+            .featureTag("feature-tag")
+            .appVersion("1.2.3")
+            .wrapperSdkSourceId(si.value)
+            .build()
+        }
       assertThat(error).hasMessageThat().contains("Unsupported wrapperSdkSourceId")
     }
   }
@@ -392,10 +393,11 @@ class BKTConfigTest {
 
   @Test
   fun `resolveSdkSourceId - unsupported sourceId throws exception`() {
-    val error = assertThrows(BKTException.IllegalArgumentException::class.java) {
-      // Using an unsupported SourceId
-      resolveSdkSourceId(SourceId.IOS.value)
-    }
+    val error =
+      assertThrows(BKTException.IllegalArgumentException::class.java) {
+        // Using an unsupported SourceId
+        resolveSdkSourceId(SourceId.IOS.value)
+      }
     assertThat(error).hasMessageThat().contains("Unsupported wrapperSdkSourceId")
   }
 
@@ -413,18 +415,19 @@ class BKTConfigTest {
 
   @Test
   fun `resolveSdkVersion - non-ANDROID with blank version throws exception`() {
-    val error = assertThrows(BKTException.IllegalArgumentException::class.java) {
-      resolveSdkVersion(SourceId.FLUTTER, "")
-    }
+    val error =
+      assertThrows(BKTException.IllegalArgumentException::class.java) {
+        resolveSdkVersion(SourceId.FLUTTER, "")
+      }
     assertThat(error).hasMessageThat().contains("wrapperSdkVersion is required when sourceId is not ANDROID")
   }
 
   @Test
   fun `resolveSdkVersion - non-ANDROID with null version throws exception`() {
-    val error = assertThrows(BKTException.IllegalArgumentException::class.java) {
-      resolveSdkVersion(SourceId.FLUTTER, null)
-    }
+    val error =
+      assertThrows(BKTException.IllegalArgumentException::class.java) {
+        resolveSdkVersion(SourceId.FLUTTER, null)
+      }
     assertThat(error).hasMessageThat().contains("wrapperSdkVersion is required when sourceId is not ANDROID")
   }
 }
-

--- a/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/BKTConfigTest.kt
+++ b/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/BKTConfigTest.kt
@@ -374,24 +374,24 @@ class BKTConfigTest {
 
   @Test
   fun `resolveSdkSourceId - null returns ANDROID`() {
-    val result = resolveSdkSourceId(null)
+    val result = resolveSdkSourceId(wrapperSdkSourceIdValue = null)
     assertThat(result).isEqualTo(SourceId.ANDROID)
   }
 
   @Test
   fun `resolveSdkSourceId - FLUTTER returns FLUTTER`() {
-    val result = resolveSdkSourceId(SourceId.FLUTTER.value)
+    val result = resolveSdkSourceId(wrapperSdkSourceIdValue = SourceId.FLUTTER.value)
     assertThat(result).isEqualTo(SourceId.FLUTTER)
   }
 
   @Test
   fun `resolveSdkSourceId - OPEN_FEATURE_KOTLIN returns OPEN_FEATURE_KOTLIN`() {
-    val result = resolveSdkSourceId(SourceId.OPEN_FEATURE_KOTLIN.value)
+    val result = resolveSdkSourceId(wrapperSdkSourceIdValue = SourceId.OPEN_FEATURE_KOTLIN.value)
     assertThat(result).isEqualTo(SourceId.OPEN_FEATURE_KOTLIN)
   }
 
   @Test
-  fun `resolveSdkSourceId - unsupported sourceId throws exception`() {
+  fun `resolveSdkSourceId - unsupported wrapperSdk sourceId throws exception`() {
     val listSourceIds =
       SourceId.entries.filter {
         it != SourceId.FLUTTER && it != SourceId.OPEN_FEATURE_KOTLIN
@@ -399,8 +399,8 @@ class BKTConfigTest {
     for (si in listSourceIds) {
       val error =
         assertThrows(BKTException.IllegalArgumentException::class.java) {
-          // Using an unsupported SourceId
-          resolveSdkSourceId(si.value)
+          // Using an unsupported wrapperSdk SourceId
+          resolveSdkSourceId(wrapperSdkSourceIdValue = si.value)
         }
       assertThat(error).hasMessageThat().contains("Unsupported wrapperSdkSourceId")
     }
@@ -424,7 +424,8 @@ class BKTConfigTest {
       assertThrows(BKTException.IllegalArgumentException::class.java) {
         resolveSdkVersion(SourceId.FLUTTER, "")
       }
-    assertThat(error).hasMessageThat()
+    assertThat(error)
+      .hasMessageThat()
       .contains("wrapperSdkVersion is required when sourceId is not ANDROID")
   }
 
@@ -434,7 +435,8 @@ class BKTConfigTest {
       assertThrows(BKTException.IllegalArgumentException::class.java) {
         resolveSdkVersion(SourceId.FLUTTER, null)
       }
-    assertThat(error).hasMessageThat()
+    assertThat(error)
+      .hasMessageThat()
       .contains("wrapperSdkVersion is required when sourceId is not ANDROID")
   }
 }

--- a/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/TestHelpers.kt
+++ b/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/TestHelpers.kt
@@ -59,6 +59,6 @@ internal fun createTestBKTConfig(
     backgroundPollingInterval = backgroundPollingInterval,
     appVersion = appVersion,
     logger = logger,
-    sourceIdValue = SourceId.ANDROID.value,
+    sourceIdNumber = SourceId.ANDROID.value,
     sdkVersion = BuildConfig.SDK_VERSION,
   )

--- a/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/TestHelpers.kt
+++ b/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/TestHelpers.kt
@@ -59,6 +59,6 @@ internal fun createTestBKTConfig(
     backgroundPollingInterval = backgroundPollingInterval,
     appVersion = appVersion,
     logger = logger,
-    sourceIdNumber = SourceId.ANDROID.value,
+    sourceIdValue = SourceId.ANDROID.value,
     sdkVersion = BuildConfig.SDK_VERSION,
   )

--- a/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/internal/remote/ApiClientImplTest.kt
+++ b/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/internal/remote/ApiClientImplTest.kt
@@ -210,7 +210,7 @@ internal class ApiClientImplTest {
         condition =
           UserEvaluationCondition(
             evaluatedAt = "1690798100",
-            userAttributesUpdated = "true",
+            userAttributesUpdated = true,
           ),
       )
 
@@ -231,7 +231,7 @@ internal class ApiClientImplTest {
         userEvaluationCondition =
           UserEvaluationCondition(
             evaluatedAt = "1690798100",
-            userAttributesUpdated = "true",
+            userAttributesUpdated = true,
           ),
         sourceId = SourceId.FLUTTER,
         sdkVersion = "10.2.3",


### PR DESCRIPTION
### Changes
- The `wrapperSdkVersion` is now required when setting `wrapperSdkSourceId` refs:[ js-sdk ](https://github.com/bucketeer-io/javascript-client-sdk/pull/224)
- Fixed build error when we merged the following [commit](https://github.com/bucketeer-io/android-client-sdk/commit/7c02cc057ae7bbda0757434a6d4f68136a0e56c4) before updating it with the main branch; there was an error. Some code conflicted and overwrote each other.



