### PR TITLE
feat: add detailed reason error types

### DIFF
--- a/bucketeer/src/androidTest/kotlin/io/bucketeer/sdk/android/e2e/BKTClientEventTest.kt
+++ b/bucketeer/src/androidTest/kotlin/io/bucketeer/sdk/android/e2e/BKTClientEventTest.kt
@@ -159,7 +159,7 @@ class BKTClientEventTest {
         val event = it.event
         return@any type == EventType.EVALUATION &&
           event is EventData.EvaluationEvent &&
-          event.reason.type == ReasonType.CLIENT
+          event.reason.type == ReasonType.ERROR_FLAG_NOT_FOUND
       },
     ).isTrue()
 

--- a/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/BKTClientImpl.kt
+++ b/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/BKTClientImpl.kt
@@ -12,6 +12,7 @@ import io.bucketeer.sdk.android.internal.di.InteractorModule
 import io.bucketeer.sdk.android.internal.evaluation.getVariationValue
 import io.bucketeer.sdk.android.internal.event.SendEventsResult
 import io.bucketeer.sdk.android.internal.logd
+import io.bucketeer.sdk.android.internal.model.ReasonType
 import io.bucketeer.sdk.android.internal.remote.GetEvaluationsResult
 import io.bucketeer.sdk.android.internal.scheduler.TaskScheduler
 import io.bucketeer.sdk.android.internal.user.toBKTUser
@@ -196,7 +197,7 @@ internal class BKTClientImpl(
           featureTag = featureTag,
           user = user,
           featureId = featureId,
-          reason = io.bucketeer.sdk.android.internal.model.ReasonType.ERROR_FLAG_NOT_FOUND,
+          reason = ReasonType.ERROR_FLAG_NOT_FOUND,
         )
       }
       return BKTEvaluationDetails.newDefaultInstance(
@@ -234,7 +235,7 @@ internal class BKTClientImpl(
           featureTag = featureTag,
           user = user,
           featureId = featureId,
-          reason = io.bucketeer.sdk.android.internal.model.ReasonType.ERROR_WRONG_TYPE,
+          reason = ReasonType.ERROR_WRONG_TYPE,
         )
       }
       return BKTEvaluationDetails.newDefaultInstance(

--- a/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/BKTClientImpl.kt
+++ b/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/BKTClientImpl.kt
@@ -35,7 +35,6 @@ internal class BKTClientImpl(
           application = context.applicationContext as Application,
           user = user.toUser(),
           config = config,
-          executor = executor,
         ),
       interactorModule =
         InteractorModule(

--- a/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/BKTEvaluationDetails.kt
+++ b/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/BKTEvaluationDetails.kt
@@ -12,18 +12,49 @@ data class BKTEvaluationDetails<T>(
   val variationValue: T,
   val reason: Reason,
 ) {
+  /**
+   * Public enum representing the reason for a feature flag evaluation.
+   *
+   * Successful evaluation reasons:
+   * - TARGET: User matched an individual targeting rule
+   * - RULE: User matched a custom rule
+   * - DEFAULT: Using the default strategy
+   * - OFF_VARIATION: Feature flag is off
+   * - PREREQUISITE: Evaluated via a prerequisite flag
+   *
+   * Error evaluation reasons:
+   * - ERROR_NO_EVALUATIONS: No evaluations performed
+   * - ERROR_FLAG_NOT_FOUND: Feature flag not found in cache
+   * - ERROR_WRONG_TYPE: Type mismatch during value conversion
+   * - ERROR_USER_ID_NOT_SPECIFIED: User ID validation failed
+   * - ERROR_FEATURE_FLAG_ID_NOT_SPECIFIED: Feature flag ID validation failed
+   * - ERROR_EXCEPTION: Unexpected error or unknown reason
+   * - ERROR_CACHE_NOT_FOUND: Cache not ready after SDK initialization
+   *
+   * Deprecated:
+   * - CLIENT: Legacy generic client error (use ERROR_* types instead)
+   */
   enum class Reason {
     TARGET,
     RULE,
     DEFAULT,
+    @Deprecated("CLIENT is deprecated. Use error-prefixed reason types instead.")
     CLIENT,
     OFF_VARIATION,
     PREREQUISITE,
 
+    ERROR_NO_EVALUATIONS,
+    ERROR_FLAG_NOT_FOUND,
+    ERROR_WRONG_TYPE,
+    ERROR_USER_ID_NOT_SPECIFIED,
+    ERROR_FEATURE_FLAG_ID_NOT_SPECIFIED,
+    ERROR_EXCEPTION,
+    ERROR_CACHE_NOT_FOUND,
+
     ;
 
     companion object {
-      fun from(value: String): Reason = entries.firstOrNull { it.name == value } ?: CLIENT
+      fun from(value: String): Reason = entries.firstOrNull { it.name == value } ?: ERROR_EXCEPTION
     }
   }
 
@@ -65,6 +96,7 @@ data class BKTEvaluationDetails<T>(
       featureId: String,
       userId: String,
       defaultValue: T,
+      reason: Reason = Reason.ERROR_EXCEPTION,
     ): BKTEvaluationDetails<T> =
       BKTEvaluationDetails(
         featureId = featureId,
@@ -73,7 +105,7 @@ data class BKTEvaluationDetails<T>(
         variationId = "",
         variationName = "",
         variationValue = defaultValue,
-        reason = BKTEvaluationDetails.Reason.CLIENT,
+        reason = reason,
       )
   }
 }

--- a/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/BKTEvaluationDetails.kt
+++ b/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/BKTEvaluationDetails.kt
@@ -38,12 +38,11 @@ data class BKTEvaluationDetails<T>(
     TARGET,
     RULE,
     DEFAULT,
-
-    @Deprecated("CLIENT is deprecated. Use error-prefixed reason types instead.")
-    CLIENT,
     OFF_VARIATION,
     PREREQUISITE,
 
+    @Deprecated("CLIENT is deprecated. Use error-prefixed reason types instead.")
+    CLIENT,
     ERROR_NO_EVALUATIONS,
     ERROR_FLAG_NOT_FOUND,
     ERROR_WRONG_TYPE,

--- a/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/BKTEvaluationDetails.kt
+++ b/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/BKTEvaluationDetails.kt
@@ -38,6 +38,7 @@ data class BKTEvaluationDetails<T>(
     TARGET,
     RULE,
     DEFAULT,
+    
     @Deprecated("CLIENT is deprecated. Use error-prefixed reason types instead.")
     CLIENT,
     OFF_VARIATION,

--- a/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/BKTEvaluationDetails.kt
+++ b/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/BKTEvaluationDetails.kt
@@ -38,7 +38,7 @@ data class BKTEvaluationDetails<T>(
     TARGET,
     RULE,
     DEFAULT,
-    
+
     @Deprecated("CLIENT is deprecated. Use error-prefixed reason types instead.")
     CLIENT,
     OFF_VARIATION,
@@ -97,7 +97,7 @@ data class BKTEvaluationDetails<T>(
       featureId: String,
       userId: String,
       defaultValue: T,
-      reason: Reason = Reason.ERROR_EXCEPTION,
+      reason: Reason,
     ): BKTEvaluationDetails<T> =
       BKTEvaluationDetails(
         featureId = featureId,

--- a/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/event/EventCreators.kt
+++ b/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/event/EventCreators.kt
@@ -59,6 +59,7 @@ internal fun newDefaultEvaluationEvent(
   featureTag: String,
   user: User,
   featureId: String,
+  reason: ReasonType,
   appVersion: String,
   sourceId: SourceId,
   sdkVersion: String,
@@ -74,7 +75,7 @@ internal fun newDefaultEvaluationEvent(
         user = user,
         reason =
           Reason(
-            type = ReasonType.CLIENT,
+            type = reason,
           ),
         tag = featureTag,
         sourceId = sourceId,

--- a/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/event/EventInteractor.kt
+++ b/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/event/EventInteractor.kt
@@ -58,6 +58,7 @@ internal class EventInteractor(
     featureTag: String,
     user: User,
     featureId: String,
+    reason: io.bucketeer.sdk.android.internal.model.ReasonType,
   ) {
     eventSQLDao.addEvent(
       newDefaultEvaluationEvent(
@@ -66,6 +67,7 @@ internal class EventInteractor(
         featureTag = featureTag,
         user = user,
         featureId = featureId,
+        reason = reason,
         appVersion = appVersion,
         sourceId = sourceId,
         sdkVersion = sdkVersion,

--- a/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/event/EventInteractor.kt
+++ b/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/event/EventInteractor.kt
@@ -10,6 +10,7 @@ import io.bucketeer.sdk.android.internal.model.ApiId
 import io.bucketeer.sdk.android.internal.model.Evaluation
 import io.bucketeer.sdk.android.internal.model.Event
 import io.bucketeer.sdk.android.internal.model.EventData
+import io.bucketeer.sdk.android.internal.model.ReasonType
 import io.bucketeer.sdk.android.internal.model.SourceId
 import io.bucketeer.sdk.android.internal.model.User
 import io.bucketeer.sdk.android.internal.remote.ApiClient
@@ -58,7 +59,7 @@ internal class EventInteractor(
     featureTag: String,
     user: User,
     featureId: String,
-    reason: io.bucketeer.sdk.android.internal.model.ReasonType,
+    reason: ReasonType,
   ) {
     eventSQLDao.addEvent(
       newDefaultEvaluationEvent(

--- a/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/model/ReasonType.kt
+++ b/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/model/ReasonType.kt
@@ -1,16 +1,47 @@
 package io.bucketeer.sdk.android.internal.model
 
+/**
+ * Internal enum representing the reason type for feature flag evaluations.
+ *
+ * Successful evaluation reasons:
+ * - TARGET: User matched an individual targeting rule
+ * - RULE: User matched a custom rule
+ * - DEFAULT: Using the default strategy
+ * - OFF_VARIATION: Feature flag is off
+ * - PREREQUISITE: Evaluated via a prerequisite flag
+ *
+ * Error evaluation reasons:
+ * - ERROR_NO_EVALUATIONS: No evaluations performed
+ * - ERROR_FLAG_NOT_FOUND: Feature flag not found in cache
+ * - ERROR_WRONG_TYPE: Type mismatch during value conversion
+ * - ERROR_USER_ID_NOT_SPECIFIED: User ID validation failed
+ * - ERROR_FEATURE_FLAG_ID_NOT_SPECIFIED: Feature flag ID validation failed
+ * - ERROR_EXCEPTION: Unexpected error or unknown reason
+ * - ERROR_CACHE_NOT_FOUND: Cache not ready after SDK initialization
+ *
+ * Deprecated:
+ * - CLIENT: Legacy generic client error (use ERROR_* types instead)
+ */
 enum class ReasonType {
   TARGET,
   RULE,
   DEFAULT,
+  @Deprecated("CLIENT is deprecated. Use error-prefixed reason types instead.")
   CLIENT,
   OFF_VARIATION,
   PREREQUISITE,
 
+  ERROR_NO_EVALUATIONS,
+  ERROR_FLAG_NOT_FOUND,
+  ERROR_WRONG_TYPE,
+  ERROR_USER_ID_NOT_SPECIFIED,
+  ERROR_FEATURE_FLAG_ID_NOT_SPECIFIED,
+  ERROR_EXCEPTION,
+  ERROR_CACHE_NOT_FOUND,
+
   ;
 
   companion object {
-    fun from(value: String): ReasonType = values().firstOrNull { it.name == value } ?: DEFAULT
+    fun from(value: String): ReasonType = values().firstOrNull { it.name == value } ?: ERROR_EXCEPTION
   }
 }

--- a/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/model/ReasonType.kt
+++ b/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/model/ReasonType.kt
@@ -26,12 +26,11 @@ enum class ReasonType {
   TARGET,
   RULE,
   DEFAULT,
-
-  @Deprecated("CLIENT is deprecated. Use error-prefixed reason types instead.")
-  CLIENT,
   OFF_VARIATION,
   PREREQUISITE,
 
+  @Deprecated("CLIENT is deprecated. Use error-prefixed reason types instead.")
+  CLIENT,
   ERROR_NO_EVALUATIONS,
   ERROR_FLAG_NOT_FOUND,
   ERROR_WRONG_TYPE,

--- a/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/model/ReasonType.kt
+++ b/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/model/ReasonType.kt
@@ -26,6 +26,7 @@ enum class ReasonType {
   TARGET,
   RULE,
   DEFAULT,
+
   @Deprecated("CLIENT is deprecated. Use error-prefixed reason types instead.")
   CLIENT,
   OFF_VARIATION,

--- a/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/BKTClientImplTest.kt
+++ b/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/BKTClientImplTest.kt
@@ -589,6 +589,7 @@ class BKTClientImplTest {
         featureId = featureId,
         userId = user1.id,
         defaultValue = 1,
+        reason = BKTEvaluationDetails.Reason.ERROR_WRONG_TYPE,
       ),
     )
 
@@ -599,6 +600,7 @@ class BKTClientImplTest {
         featureId = featureId,
         userId = user1.id,
         defaultValue = false,
+        reason = BKTEvaluationDetails.Reason.ERROR_WRONG_TYPE,
       ),
     )
 
@@ -609,6 +611,7 @@ class BKTClientImplTest {
         featureId = featureId,
         userId = user1.id,
         defaultValue = 1.0,
+        reason = BKTEvaluationDetails.Reason.ERROR_WRONG_TYPE,
       ),
     )
 
@@ -672,28 +675,28 @@ class BKTClientImplTest {
     val userId = "user id 1"
     val unknownFeatureId = "unknownFeatureId"
     val intDefaultInstance: BKTEvaluationDetails<Int> =
-      BKTEvaluationDetails.newDefaultInstance(featureId = unknownFeatureId, userId = userId, 1)
+      BKTEvaluationDetails.newDefaultInstance(featureId = unknownFeatureId, userId = userId, 1, reason = BKTEvaluationDetails.Reason.ERROR_FLAG_NOT_FOUND)
     Assert.assertEquals(
       intDefaultInstance,
       BKTClient.getInstance().intVariationDetails(unknownFeatureId, 1),
     )
 
     val doubleDefaultInstance: BKTEvaluationDetails<Double> =
-      BKTEvaluationDetails.newDefaultInstance(featureId = unknownFeatureId, userId = userId, 1.0)
+      BKTEvaluationDetails.newDefaultInstance(featureId = unknownFeatureId, userId = userId, 1.0, reason = BKTEvaluationDetails.Reason.ERROR_FLAG_NOT_FOUND)
     Assert.assertEquals(
       doubleDefaultInstance,
       BKTClient.getInstance().doubleVariationDetails(unknownFeatureId, 1.0),
     )
 
     val booleanDefaultInstance: BKTEvaluationDetails<Boolean> =
-      BKTEvaluationDetails.newDefaultInstance(featureId = unknownFeatureId, userId = userId, true)
+      BKTEvaluationDetails.newDefaultInstance(featureId = unknownFeatureId, userId = userId, true, reason = BKTEvaluationDetails.Reason.ERROR_FLAG_NOT_FOUND)
     Assert.assertEquals(
       booleanDefaultInstance,
       BKTClient.getInstance().boolVariationDetails(unknownFeatureId, true),
     )
 
     val stringDefaultInstance: BKTEvaluationDetails<String> =
-      BKTEvaluationDetails.newDefaultInstance(featureId = unknownFeatureId, userId = userId, "1")
+      BKTEvaluationDetails.newDefaultInstance(featureId = unknownFeatureId, userId = userId, "1", reason = BKTEvaluationDetails.Reason.ERROR_FLAG_NOT_FOUND)
     Assert.assertEquals(
       stringDefaultInstance,
       BKTClient.getInstance().stringVariationDetails(unknownFeatureId, "1"),
@@ -711,6 +714,7 @@ class BKTClientImplTest {
         featureId = unknownFeatureId,
         userId = userId,
         object1,
+        reason = BKTEvaluationDetails.Reason.ERROR_FLAG_NOT_FOUND,
       )
     Assert.assertEquals(
       objectDefaultInstance,
@@ -790,6 +794,7 @@ class BKTClientImplTest {
         featureId = featureId,
         userId = user1.id,
         defaultValue = true,
+        reason = BKTEvaluationDetails.Reason.ERROR_WRONG_TYPE,
       ),
     )
 
@@ -906,6 +911,7 @@ class BKTClientImplTest {
         featureId = featureId,
         userId = user1.id,
         defaultValue = false,
+        reason = BKTEvaluationDetails.Reason.ERROR_WRONG_TYPE,
       ),
     )
 
@@ -1005,6 +1011,7 @@ class BKTClientImplTest {
         featureId = featureId,
         userId = user1.id,
         defaultValue = 3,
+        reason = BKTEvaluationDetails.Reason.ERROR_WRONG_TYPE,
       ),
     )
 
@@ -1029,6 +1036,7 @@ class BKTClientImplTest {
         featureId = featureId,
         userId = user1.id,
         defaultValue = 2.0,
+        reason = BKTEvaluationDetails.Reason.ERROR_WRONG_TYPE,
       ),
     )
 
@@ -1157,6 +1165,7 @@ class BKTClientImplTest {
         featureId = featureId,
         userId = user1.id,
         defaultValue = 10,
+        reason = BKTEvaluationDetails.Reason.ERROR_WRONG_TYPE,
       ),
     )
 
@@ -1167,6 +1176,7 @@ class BKTClientImplTest {
         featureId = featureId,
         userId = user1.id,
         defaultValue = false,
+        reason = BKTEvaluationDetails.Reason.ERROR_WRONG_TYPE,
       ),
     )
 
@@ -1177,6 +1187,7 @@ class BKTClientImplTest {
         featureId = featureId,
         userId = user1.id,
         defaultValue = 5.5,
+        reason = BKTEvaluationDetails.Reason.ERROR_WRONG_TYPE,
       ),
     )
 
@@ -1230,6 +1241,7 @@ class BKTClientImplTest {
         featureId = unknownFeature,
         userId = user1.id,
         defaultValue = "33",
+        reason = BKTEvaluationDetails.Reason.ERROR_FLAG_NOT_FOUND,
       ),
     )
 
@@ -1240,6 +1252,7 @@ class BKTClientImplTest {
         featureId = unknownFeature,
         userId = user1.id,
         defaultValue = 9,
+        reason = BKTEvaluationDetails.Reason.ERROR_FLAG_NOT_FOUND,
       ),
     )
 
@@ -1250,6 +1263,7 @@ class BKTClientImplTest {
         featureId = unknownFeature,
         userId = user1.id,
         defaultValue = 10.2,
+        reason = BKTEvaluationDetails.Reason.ERROR_FLAG_NOT_FOUND,
       ),
     )
 
@@ -1260,6 +1274,7 @@ class BKTClientImplTest {
         featureId = unknownFeature,
         userId = user1.id,
         defaultValue = true,
+        reason = BKTEvaluationDetails.Reason.ERROR_FLAG_NOT_FOUND,
       ),
     )
 
@@ -1273,6 +1288,7 @@ class BKTClientImplTest {
         featureId = unknownFeature,
         userId = user1.id,
         defaultValue = BKTValue.Structure(mapOf("key" to BKTValue.String("value-1"))),
+        reason = BKTEvaluationDetails.Reason.ERROR_FLAG_NOT_FOUND,
       ),
     )
   }

--- a/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/BKTClientImplTest.kt
+++ b/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/BKTClientImplTest.kt
@@ -675,28 +675,48 @@ class BKTClientImplTest {
     val userId = "user id 1"
     val unknownFeatureId = "unknownFeatureId"
     val intDefaultInstance: BKTEvaluationDetails<Int> =
-      BKTEvaluationDetails.newDefaultInstance(featureId = unknownFeatureId, userId = userId, 1, reason = BKTEvaluationDetails.Reason.ERROR_FLAG_NOT_FOUND)
+      BKTEvaluationDetails.newDefaultInstance(
+        featureId = unknownFeatureId,
+        userId = userId,
+        1,
+        reason = BKTEvaluationDetails.Reason.ERROR_FLAG_NOT_FOUND,
+      )
     Assert.assertEquals(
       intDefaultInstance,
       BKTClient.getInstance().intVariationDetails(unknownFeatureId, 1),
     )
 
     val doubleDefaultInstance: BKTEvaluationDetails<Double> =
-      BKTEvaluationDetails.newDefaultInstance(featureId = unknownFeatureId, userId = userId, 1.0, reason = BKTEvaluationDetails.Reason.ERROR_FLAG_NOT_FOUND)
+      BKTEvaluationDetails.newDefaultInstance(
+        featureId = unknownFeatureId,
+        userId = userId,
+        1.0,
+        reason = BKTEvaluationDetails.Reason.ERROR_FLAG_NOT_FOUND,
+      )
     Assert.assertEquals(
       doubleDefaultInstance,
       BKTClient.getInstance().doubleVariationDetails(unknownFeatureId, 1.0),
     )
 
     val booleanDefaultInstance: BKTEvaluationDetails<Boolean> =
-      BKTEvaluationDetails.newDefaultInstance(featureId = unknownFeatureId, userId = userId, true, reason = BKTEvaluationDetails.Reason.ERROR_FLAG_NOT_FOUND)
+      BKTEvaluationDetails.newDefaultInstance(
+        featureId = unknownFeatureId,
+        userId = userId,
+        true,
+        reason = BKTEvaluationDetails.Reason.ERROR_FLAG_NOT_FOUND,
+      )
     Assert.assertEquals(
       booleanDefaultInstance,
       BKTClient.getInstance().boolVariationDetails(unknownFeatureId, true),
     )
 
     val stringDefaultInstance: BKTEvaluationDetails<String> =
-      BKTEvaluationDetails.newDefaultInstance(featureId = unknownFeatureId, userId = userId, "1", reason = BKTEvaluationDetails.Reason.ERROR_FLAG_NOT_FOUND)
+      BKTEvaluationDetails.newDefaultInstance(
+        featureId = unknownFeatureId,
+        userId = userId,
+        "1",
+        reason = BKTEvaluationDetails.Reason.ERROR_FLAG_NOT_FOUND,
+      )
     Assert.assertEquals(
       stringDefaultInstance,
       BKTClient.getInstance().stringVariationDetails(unknownFeatureId, "1"),

--- a/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/BKTEvaluationDetailsTest.kt
+++ b/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/BKTEvaluationDetailsTest.kt
@@ -111,12 +111,13 @@ class BKTEvaluationDetailsTest {
       ),
     )
 
-    val object1 = BKTValue.Structure(
-      mapOf(
-        "key1" to BKTValue.String("value1"),
-        "key" to BKTValue.String("value"),
-      ),
-    )
+    val object1 =
+      BKTValue.Structure(
+        mapOf(
+          "key1" to BKTValue.String("value1"),
+          "key" to BKTValue.String("value"),
+        ),
+      )
     val object1DefaultInstance: BKTEvaluationDetails<BKTValue> =
       BKTEvaluationDetails.newDefaultInstance(
         featureId = featureId,
@@ -382,12 +383,13 @@ class BKTEvaluationDetailsTest {
         userId = "user2",
         variationId = "var2",
         variationName = "name2",
-        variationValue = BKTValue.List(
-          listOf(
-            BKTValue.String("value1"),
-            BKTValue.String("value2"),
+        variationValue =
+          BKTValue.List(
+            listOf(
+              BKTValue.String("value1"),
+              BKTValue.String("value2"),
+            ),
           ),
-        ),
         reason = BKTEvaluationDetails.Reason.RULE,
       )
 
@@ -398,12 +400,13 @@ class BKTEvaluationDetailsTest {
         userId = "user2",
         variationId = "var2",
         variationName = "name2",
-        variationValue = BKTValue.List(
-          listOf(
-            BKTValue.String("value1"),
-            BKTValue.String("value2"),
+        variationValue =
+          BKTValue.List(
+            listOf(
+              BKTValue.String("value1"),
+              BKTValue.String("value2"),
+            ),
           ),
-        ),
         reason = BKTEvaluationDetails.Reason.RULE,
       )
 
@@ -424,12 +427,13 @@ class BKTEvaluationDetailsTest {
         userId = "user2",
         variationId = "var2",
         variationName = "name2",
-        variationValue = BKTValue.Structure(
-          mapOf(
-            "key1" to BKTValue.String("value1"),
-            "key2" to BKTValue.String("value2"),
+        variationValue =
+          BKTValue.Structure(
+            mapOf(
+              "key1" to BKTValue.String("value1"),
+              "key2" to BKTValue.String("value2"),
+            ),
           ),
-        ),
         reason = BKTEvaluationDetails.Reason.RULE,
       )
 
@@ -440,25 +444,28 @@ class BKTEvaluationDetailsTest {
         userId = "user2",
         variationId = "var2",
         variationName = "name2",
-        variationValue = BKTValue.Structure(
-          mapOf(
-            "key1" to BKTValue.String("value1"),
-            "key2" to BKTValue.String("value2"),
+        variationValue =
+          BKTValue.Structure(
+            mapOf(
+              "key1" to BKTValue.String("value1"),
+              "key2" to BKTValue.String("value2"),
+            ),
           ),
-        ),
         reason = BKTEvaluationDetails.Reason.RULE,
       )
 
     assertEquals(detail1, detail2)
     assertNotEquals(
       detail1.copy(
-        variationValue = BKTValue.Structure(
-          mapOf(
-            "key3" to BKTValue.String(
-              "value3",
+        variationValue =
+          BKTValue.Structure(
+            mapOf(
+              "key3" to
+                BKTValue.String(
+                  "value3",
+                ),
             ),
           ),
-        ),
       ),
       detail2,
     )

--- a/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/BKTEvaluationDetailsTest.kt
+++ b/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/BKTEvaluationDetailsTest.kt
@@ -21,7 +21,7 @@ class BKTEvaluationDetailsTest {
         variationId = "",
         variationName = "",
         variationValue = 1,
-        reason = BKTEvaluationDetails.Reason.CLIENT,
+        reason = BKTEvaluationDetails.Reason.ERROR_EXCEPTION,
       ),
     )
 
@@ -36,7 +36,7 @@ class BKTEvaluationDetailsTest {
         variationId = "",
         variationName = "",
         variationValue = 1.0,
-        reason = BKTEvaluationDetails.Reason.CLIENT,
+        reason = BKTEvaluationDetails.Reason.ERROR_EXCEPTION,
       ),
     )
 
@@ -51,7 +51,7 @@ class BKTEvaluationDetailsTest {
         variationId = "",
         variationName = "",
         variationValue = true,
-        reason = BKTEvaluationDetails.Reason.CLIENT,
+        reason = BKTEvaluationDetails.Reason.ERROR_EXCEPTION,
       ),
     )
 
@@ -66,7 +66,7 @@ class BKTEvaluationDetailsTest {
         variationId = "",
         variationName = "",
         variationValue = "1",
-        reason = BKTEvaluationDetails.Reason.CLIENT,
+        reason = BKTEvaluationDetails.Reason.ERROR_EXCEPTION,
       ),
     )
 
@@ -82,7 +82,7 @@ class BKTEvaluationDetailsTest {
         variationId = "",
         variationName = "",
         variationValue = json1,
-        reason = BKTEvaluationDetails.Reason.CLIENT,
+        reason = BKTEvaluationDetails.Reason.ERROR_EXCEPTION,
       ),
     )
 
@@ -98,7 +98,7 @@ class BKTEvaluationDetailsTest {
         variationId = "",
         variationName = "",
         variationValue = object1,
-        reason = BKTEvaluationDetails.Reason.CLIENT,
+        reason = BKTEvaluationDetails.Reason.ERROR_EXCEPTION,
       ),
     )
   }
@@ -427,15 +427,27 @@ class BKTEvaluationDetailsTest {
 
   @Test
   fun testReasonFrom() {
-    // Test cases for each valid Reason
+    // Test cases for each valid Reason - successful evaluations
     assertEquals(BKTEvaluationDetails.Reason.TARGET, BKTEvaluationDetails.Reason.from("TARGET"))
     assertEquals(BKTEvaluationDetails.Reason.RULE, BKTEvaluationDetails.Reason.from("RULE"))
     assertEquals(BKTEvaluationDetails.Reason.DEFAULT, BKTEvaluationDetails.Reason.from("DEFAULT"))
-    assertEquals(BKTEvaluationDetails.Reason.CLIENT, BKTEvaluationDetails.Reason.from("CLIENT"))
     assertEquals(BKTEvaluationDetails.Reason.OFF_VARIATION, BKTEvaluationDetails.Reason.from("OFF_VARIATION"))
     assertEquals(BKTEvaluationDetails.Reason.PREREQUISITE, BKTEvaluationDetails.Reason.from("PREREQUISITE"))
 
-    // Test case for an invalid Reason which should return CLIENT as default
-    assertEquals(BKTEvaluationDetails.Reason.CLIENT, BKTEvaluationDetails.Reason.from("INVALID_REASON"))
+    // Test cases for error reason types
+    assertEquals(BKTEvaluationDetails.Reason.ERROR_NO_EVALUATIONS, BKTEvaluationDetails.Reason.from("ERROR_NO_EVALUATIONS"))
+    assertEquals(BKTEvaluationDetails.Reason.ERROR_FLAG_NOT_FOUND, BKTEvaluationDetails.Reason.from("ERROR_FLAG_NOT_FOUND"))
+    assertEquals(BKTEvaluationDetails.Reason.ERROR_WRONG_TYPE, BKTEvaluationDetails.Reason.from("ERROR_WRONG_TYPE"))
+    assertEquals(BKTEvaluationDetails.Reason.ERROR_USER_ID_NOT_SPECIFIED, BKTEvaluationDetails.Reason.from("ERROR_USER_ID_NOT_SPECIFIED"))
+    assertEquals(BKTEvaluationDetails.Reason.ERROR_FEATURE_FLAG_ID_NOT_SPECIFIED, BKTEvaluationDetails.Reason.from("ERROR_FEATURE_FLAG_ID_NOT_SPECIFIED"))
+    assertEquals(BKTEvaluationDetails.Reason.ERROR_EXCEPTION, BKTEvaluationDetails.Reason.from("ERROR_EXCEPTION"))
+    assertEquals(BKTEvaluationDetails.Reason.ERROR_CACHE_NOT_FOUND, BKTEvaluationDetails.Reason.from("ERROR_CACHE_NOT_FOUND"))
+
+    // Test deprecated CLIENT reason type
+    @Suppress("DEPRECATION")
+    assertEquals(BKTEvaluationDetails.Reason.CLIENT, BKTEvaluationDetails.Reason.from("CLIENT"))
+
+    // Test case for an invalid Reason which should return ERROR_EXCEPTION as default
+    assertEquals(BKTEvaluationDetails.Reason.ERROR_EXCEPTION, BKTEvaluationDetails.Reason.from("INVALID_REASON"))
   }
 }

--- a/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/BKTEvaluationDetailsTest.kt
+++ b/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/BKTEvaluationDetailsTest.kt
@@ -11,7 +11,12 @@ class BKTEvaluationDetailsTest {
     val userId = "1"
     val featureId = "1001"
     val intDefaultInstance: BKTEvaluationDetails<Int> =
-      BKTEvaluationDetails.newDefaultInstance(featureId = featureId, userId = userId, 1)
+      BKTEvaluationDetails.newDefaultInstance(
+        featureId = featureId,
+        userId = userId,
+        1,
+        reason = BKTEvaluationDetails.Reason.ERROR_FLAG_NOT_FOUND,
+      )
     assertEquals(
       intDefaultInstance,
       BKTEvaluationDetails(
@@ -21,12 +26,17 @@ class BKTEvaluationDetailsTest {
         variationId = "",
         variationName = "",
         variationValue = 1,
-        reason = BKTEvaluationDetails.Reason.ERROR_EXCEPTION,
+        reason = BKTEvaluationDetails.Reason.ERROR_FLAG_NOT_FOUND,
       ),
     )
 
     val doubleDefaultInstance: BKTEvaluationDetails<Double> =
-      BKTEvaluationDetails.newDefaultInstance(featureId = featureId, userId = userId, 1.0)
+      BKTEvaluationDetails.newDefaultInstance(
+        featureId = featureId,
+        userId = userId,
+        1.0,
+        reason = BKTEvaluationDetails.Reason.ERROR_EXCEPTION,
+      )
     assertEquals(
       doubleDefaultInstance,
       BKTEvaluationDetails(
@@ -41,7 +51,12 @@ class BKTEvaluationDetailsTest {
     )
 
     val booleanDefaultInstance: BKTEvaluationDetails<Boolean> =
-      BKTEvaluationDetails.newDefaultInstance(featureId = featureId, userId = userId, true)
+      BKTEvaluationDetails.newDefaultInstance(
+        featureId = featureId,
+        userId = userId,
+        true,
+        reason = BKTEvaluationDetails.Reason.ERROR_EXCEPTION,
+      )
     assertEquals(
       booleanDefaultInstance,
       BKTEvaluationDetails(
@@ -56,7 +71,12 @@ class BKTEvaluationDetailsTest {
     )
 
     val stringDefaultInstance: BKTEvaluationDetails<String> =
-      BKTEvaluationDetails.newDefaultInstance(featureId = featureId, userId = userId, "1")
+      BKTEvaluationDetails.newDefaultInstance(
+        featureId = featureId,
+        userId = userId,
+        "1",
+        reason = BKTEvaluationDetails.Reason.ERROR_EXCEPTION,
+      )
     assertEquals(
       stringDefaultInstance,
       BKTEvaluationDetails(
@@ -72,7 +92,12 @@ class BKTEvaluationDetailsTest {
 
     val json1 = JSONObject("{\"key1\": \"value1\", \"key\": \"value\"}")
     val jsonDefaultInstance: BKTEvaluationDetails<JSONObject> =
-      BKTEvaluationDetails.newDefaultInstance(featureId = featureId, userId = userId, json1)
+      BKTEvaluationDetails.newDefaultInstance(
+        featureId = featureId,
+        userId = userId,
+        json1,
+        reason = BKTEvaluationDetails.Reason.ERROR_FLAG_NOT_FOUND,
+      )
     assertEquals(
       jsonDefaultInstance,
       BKTEvaluationDetails(
@@ -82,13 +107,23 @@ class BKTEvaluationDetailsTest {
         variationId = "",
         variationName = "",
         variationValue = json1,
-        reason = BKTEvaluationDetails.Reason.ERROR_EXCEPTION,
+        reason = BKTEvaluationDetails.Reason.ERROR_FLAG_NOT_FOUND,
       ),
     )
 
-    val object1 = BKTValue.Structure(mapOf("key1" to BKTValue.String("value1"), "key" to BKTValue.String("value")))
+    val object1 = BKTValue.Structure(
+      mapOf(
+        "key1" to BKTValue.String("value1"),
+        "key" to BKTValue.String("value"),
+      ),
+    )
     val object1DefaultInstance: BKTEvaluationDetails<BKTValue> =
-      BKTEvaluationDetails.newDefaultInstance(featureId = featureId, userId = userId, object1)
+      BKTEvaluationDetails.newDefaultInstance(
+        featureId = featureId,
+        userId = userId,
+        object1,
+        reason = BKTEvaluationDetails.Reason.ERROR_EXCEPTION,
+      )
     assertEquals(
       object1DefaultInstance,
       BKTEvaluationDetails(
@@ -347,7 +382,12 @@ class BKTEvaluationDetailsTest {
         userId = "user2",
         variationId = "var2",
         variationName = "name2",
-        variationValue = BKTValue.List(listOf(BKTValue.String("value1"), BKTValue.String("value2"))),
+        variationValue = BKTValue.List(
+          listOf(
+            BKTValue.String("value1"),
+            BKTValue.String("value2"),
+          ),
+        ),
         reason = BKTEvaluationDetails.Reason.RULE,
       )
 
@@ -358,12 +398,20 @@ class BKTEvaluationDetailsTest {
         userId = "user2",
         variationId = "var2",
         variationName = "name2",
-        variationValue = BKTValue.List(listOf(BKTValue.String("value1"), BKTValue.String("value2"))),
+        variationValue = BKTValue.List(
+          listOf(
+            BKTValue.String("value1"),
+            BKTValue.String("value2"),
+          ),
+        ),
         reason = BKTEvaluationDetails.Reason.RULE,
       )
 
     assertEquals(detail1, detail2)
-    assertNotEquals(detail1.copy(variationValue = BKTValue.List(listOf(BKTValue.String("value3")))), detail2)
+    assertNotEquals(
+      detail1.copy(variationValue = BKTValue.List(listOf(BKTValue.String("value3")))),
+      detail2,
+    )
     assertNotEquals(detail1.copy(featureId = "2", featureVersion = 2), detail2)
   }
 
@@ -376,7 +424,12 @@ class BKTEvaluationDetailsTest {
         userId = "user2",
         variationId = "var2",
         variationName = "name2",
-        variationValue = BKTValue.Structure(mapOf("key1" to BKTValue.String("value1"), "key2" to BKTValue.String("value2"))),
+        variationValue = BKTValue.Structure(
+          mapOf(
+            "key1" to BKTValue.String("value1"),
+            "key2" to BKTValue.String("value2"),
+          ),
+        ),
         reason = BKTEvaluationDetails.Reason.RULE,
       )
 
@@ -387,12 +440,28 @@ class BKTEvaluationDetailsTest {
         userId = "user2",
         variationId = "var2",
         variationName = "name2",
-        variationValue = BKTValue.Structure(mapOf("key1" to BKTValue.String("value1"), "key2" to BKTValue.String("value2"))),
+        variationValue = BKTValue.Structure(
+          mapOf(
+            "key1" to BKTValue.String("value1"),
+            "key2" to BKTValue.String("value2"),
+          ),
+        ),
         reason = BKTEvaluationDetails.Reason.RULE,
       )
 
     assertEquals(detail1, detail2)
-    assertNotEquals(detail1.copy(variationValue = BKTValue.Structure(mapOf("key3" to BKTValue.String("value3")))), detail2)
+    assertNotEquals(
+      detail1.copy(
+        variationValue = BKTValue.Structure(
+          mapOf(
+            "key3" to BKTValue.String(
+              "value3",
+            ),
+          ),
+        ),
+      ),
+      detail2,
+    )
     assertNotEquals(detail1.copy(featureId = "2", featureVersion = 2), detail2)
   }
 
@@ -431,23 +500,53 @@ class BKTEvaluationDetailsTest {
     assertEquals(BKTEvaluationDetails.Reason.TARGET, BKTEvaluationDetails.Reason.from("TARGET"))
     assertEquals(BKTEvaluationDetails.Reason.RULE, BKTEvaluationDetails.Reason.from("RULE"))
     assertEquals(BKTEvaluationDetails.Reason.DEFAULT, BKTEvaluationDetails.Reason.from("DEFAULT"))
-    assertEquals(BKTEvaluationDetails.Reason.OFF_VARIATION, BKTEvaluationDetails.Reason.from("OFF_VARIATION"))
-    assertEquals(BKTEvaluationDetails.Reason.PREREQUISITE, BKTEvaluationDetails.Reason.from("PREREQUISITE"))
+    assertEquals(
+      BKTEvaluationDetails.Reason.OFF_VARIATION,
+      BKTEvaluationDetails.Reason.from("OFF_VARIATION"),
+    )
+    assertEquals(
+      BKTEvaluationDetails.Reason.PREREQUISITE,
+      BKTEvaluationDetails.Reason.from("PREREQUISITE"),
+    )
 
     // Test cases for error reason types
-    assertEquals(BKTEvaluationDetails.Reason.ERROR_NO_EVALUATIONS, BKTEvaluationDetails.Reason.from("ERROR_NO_EVALUATIONS"))
-    assertEquals(BKTEvaluationDetails.Reason.ERROR_FLAG_NOT_FOUND, BKTEvaluationDetails.Reason.from("ERROR_FLAG_NOT_FOUND"))
-    assertEquals(BKTEvaluationDetails.Reason.ERROR_WRONG_TYPE, BKTEvaluationDetails.Reason.from("ERROR_WRONG_TYPE"))
-    assertEquals(BKTEvaluationDetails.Reason.ERROR_USER_ID_NOT_SPECIFIED, BKTEvaluationDetails.Reason.from("ERROR_USER_ID_NOT_SPECIFIED"))
-    assertEquals(BKTEvaluationDetails.Reason.ERROR_FEATURE_FLAG_ID_NOT_SPECIFIED, BKTEvaluationDetails.Reason.from("ERROR_FEATURE_FLAG_ID_NOT_SPECIFIED"))
-    assertEquals(BKTEvaluationDetails.Reason.ERROR_EXCEPTION, BKTEvaluationDetails.Reason.from("ERROR_EXCEPTION"))
-    assertEquals(BKTEvaluationDetails.Reason.ERROR_CACHE_NOT_FOUND, BKTEvaluationDetails.Reason.from("ERROR_CACHE_NOT_FOUND"))
+    assertEquals(
+      BKTEvaluationDetails.Reason.ERROR_NO_EVALUATIONS,
+      BKTEvaluationDetails.Reason.from("ERROR_NO_EVALUATIONS"),
+    )
+    assertEquals(
+      BKTEvaluationDetails.Reason.ERROR_FLAG_NOT_FOUND,
+      BKTEvaluationDetails.Reason.from("ERROR_FLAG_NOT_FOUND"),
+    )
+    assertEquals(
+      BKTEvaluationDetails.Reason.ERROR_WRONG_TYPE,
+      BKTEvaluationDetails.Reason.from("ERROR_WRONG_TYPE"),
+    )
+    assertEquals(
+      BKTEvaluationDetails.Reason.ERROR_USER_ID_NOT_SPECIFIED,
+      BKTEvaluationDetails.Reason.from("ERROR_USER_ID_NOT_SPECIFIED"),
+    )
+    assertEquals(
+      BKTEvaluationDetails.Reason.ERROR_FEATURE_FLAG_ID_NOT_SPECIFIED,
+      BKTEvaluationDetails.Reason.from("ERROR_FEATURE_FLAG_ID_NOT_SPECIFIED"),
+    )
+    assertEquals(
+      BKTEvaluationDetails.Reason.ERROR_EXCEPTION,
+      BKTEvaluationDetails.Reason.from("ERROR_EXCEPTION"),
+    )
+    assertEquals(
+      BKTEvaluationDetails.Reason.ERROR_CACHE_NOT_FOUND,
+      BKTEvaluationDetails.Reason.from("ERROR_CACHE_NOT_FOUND"),
+    )
 
     // Test deprecated CLIENT reason type
     @Suppress("DEPRECATION")
     assertEquals(BKTEvaluationDetails.Reason.CLIENT, BKTEvaluationDetails.Reason.from("CLIENT"))
 
     // Test case for an invalid Reason which should return ERROR_EXCEPTION as default
-    assertEquals(BKTEvaluationDetails.Reason.ERROR_EXCEPTION, BKTEvaluationDetails.Reason.from("INVALID_REASON"))
+    assertEquals(
+      BKTEvaluationDetails.Reason.ERROR_EXCEPTION,
+      BKTEvaluationDetails.Reason.from("INVALID_REASON"),
+    )
   }
 }

--- a/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/internal/event/EventInteractorTest.kt
+++ b/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/internal/event/EventInteractorTest.kt
@@ -44,7 +44,6 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import java.net.SocketTimeoutException
-import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 
 @RunWith(RobolectricTestRunner::class)
@@ -1092,7 +1091,7 @@ private class TestDataModule(
   application: Application,
   config: BKTConfig,
   defaultRequestTimeoutMillis: Long,
-) : DataModule(application, user1, config, inMemoryDB = true, executor = Executors.newSingleThreadScheduledExecutor()) {
+) : DataModule(application, user1, config, inMemoryDB = true) {
   override val clock: Clock by lazy { FakeClock() }
 
   override val idGenerator: IdGenerator by lazy { FakeIdGenerator() }
@@ -1106,7 +1105,6 @@ private class TestDataModule(
       defaultRequestTimeoutMillis = defaultRequestTimeoutMillis,
       sourceId = config.sourceId,
       sdkVersion = config.sdkVersion,
-      retrier = retrier,
     )
   }
 }

--- a/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/internal/event/EventInteractorTest.kt
+++ b/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/internal/event/EventInteractorTest.kt
@@ -44,6 +44,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import java.net.SocketTimeoutException
+import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 
 @RunWith(RobolectricTestRunner::class)
@@ -150,7 +151,12 @@ class EventInteractorTest {
 
     interactor.setEventUpdateListener(listener)
 
-    interactor.trackDefaultEvaluationEvent("feature_tag_value", user1, "feature_id_value")
+    interactor.trackDefaultEvaluationEvent(
+      "feature_tag_value",
+      user1,
+      "feature_id_value",
+      ReasonType.ERROR_FLAG_NOT_FOUND,
+    )
 
     assertThat(listener.calls).hasSize(1)
     assertThat(listener.calls[0]).hasSize(1)
@@ -170,7 +176,7 @@ class EventInteractorTest {
             featureId = "feature_id_value",
             userId = user1.id,
             user = user1,
-            reason = Reason(ReasonType.CLIENT),
+            reason = Reason(ReasonType.ERROR_FLAG_NOT_FOUND),
             tag = "feature_tag_value",
             sourceId = config.sourceId,
             sdkVersion = config.sdkVersion,
@@ -1086,7 +1092,7 @@ private class TestDataModule(
   application: Application,
   config: BKTConfig,
   defaultRequestTimeoutMillis: Long,
-) : DataModule(application, user1, config, inMemoryDB = true) {
+) : DataModule(application, user1, config, inMemoryDB = true, executor = Executors.newSingleThreadScheduledExecutor()) {
   override val clock: Clock by lazy { FakeClock() }
 
   override val idGenerator: IdGenerator by lazy { FakeIdGenerator() }
@@ -1100,6 +1106,7 @@ private class TestDataModule(
       defaultRequestTimeoutMillis = defaultRequestTimeoutMillis,
       sourceId = config.sourceId,
       sdkVersion = config.sdkVersion,
+      retrier = retrier,
     )
   }
 }

--- a/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/internal/model/ReasonTypeTest.kt
+++ b/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/internal/model/ReasonTypeTest.kt
@@ -1,0 +1,72 @@
+package io.bucketeer.sdk.android.internal.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ReasonTypeTest {
+  @Test
+  fun testReasonTypeFromValidValues() {
+    // Test successful evaluation reasons
+    assertEquals(ReasonType.TARGET, ReasonType.from("TARGET"))
+    assertEquals(ReasonType.RULE, ReasonType.from("RULE"))
+    assertEquals(ReasonType.DEFAULT, ReasonType.from("DEFAULT"))
+    assertEquals(ReasonType.OFF_VARIATION, ReasonType.from("OFF_VARIATION"))
+    assertEquals(ReasonType.PREREQUISITE, ReasonType.from("PREREQUISITE"))
+
+    // Test error evaluation reasons
+    assertEquals(ReasonType.ERROR_NO_EVALUATIONS, ReasonType.from("ERROR_NO_EVALUATIONS"))
+    assertEquals(ReasonType.ERROR_FLAG_NOT_FOUND, ReasonType.from("ERROR_FLAG_NOT_FOUND"))
+    assertEquals(ReasonType.ERROR_WRONG_TYPE, ReasonType.from("ERROR_WRONG_TYPE"))
+    assertEquals(ReasonType.ERROR_USER_ID_NOT_SPECIFIED, ReasonType.from("ERROR_USER_ID_NOT_SPECIFIED"))
+    assertEquals(ReasonType.ERROR_FEATURE_FLAG_ID_NOT_SPECIFIED, ReasonType.from("ERROR_FEATURE_FLAG_ID_NOT_SPECIFIED"))
+    assertEquals(ReasonType.ERROR_EXCEPTION, ReasonType.from("ERROR_EXCEPTION"))
+    assertEquals(ReasonType.ERROR_CACHE_NOT_FOUND, ReasonType.from("ERROR_CACHE_NOT_FOUND"))
+
+    // Test deprecated CLIENT reason type
+    @Suppress("DEPRECATION")
+    assertEquals(ReasonType.CLIENT, ReasonType.from("CLIENT"))
+  }
+
+  @Test
+  fun testReasonTypeFromInvalidValue() {
+    // Test that invalid values default to ERROR_EXCEPTION
+    assertEquals(ReasonType.ERROR_EXCEPTION, ReasonType.from("INVALID_VALUE"))
+    assertEquals(ReasonType.ERROR_EXCEPTION, ReasonType.from(""))
+    assertEquals(ReasonType.ERROR_EXCEPTION, ReasonType.from("UNKNOWN"))
+    assertEquals(ReasonType.ERROR_EXCEPTION, ReasonType.from("random_string"))
+  }
+
+  @Test
+  fun testAllReasonTypesCanBeParsed() {
+    // Verify all enum values (except deprecated CLIENT) can be parsed and roundtrip correctly
+    ReasonType.values().forEach { reasonType ->
+      if (reasonType != ReasonType.CLIENT) {
+        assertEquals(reasonType, ReasonType.from(reasonType.name))
+      }
+    }
+  }
+
+  @Test
+  fun testReasonTypeEnumValues() {
+    // Verify all expected reason types are present in the enum
+    val expectedValues = setOf(
+      ReasonType.TARGET,
+      ReasonType.RULE,
+      ReasonType.DEFAULT,
+      @Suppress("DEPRECATION")
+      ReasonType.CLIENT,
+      ReasonType.OFF_VARIATION,
+      ReasonType.PREREQUISITE,
+      ReasonType.ERROR_NO_EVALUATIONS,
+      ReasonType.ERROR_FLAG_NOT_FOUND,
+      ReasonType.ERROR_WRONG_TYPE,
+      ReasonType.ERROR_USER_ID_NOT_SPECIFIED,
+      ReasonType.ERROR_FEATURE_FLAG_ID_NOT_SPECIFIED,
+      ReasonType.ERROR_EXCEPTION,
+      ReasonType.ERROR_CACHE_NOT_FOUND,
+    )
+
+    val actualValues = ReasonType.values().toSet()
+    assertEquals(expectedValues, actualValues)
+  }
+}

--- a/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/internal/model/ReasonTypeTest.kt
+++ b/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/internal/model/ReasonTypeTest.kt
@@ -49,22 +49,23 @@ class ReasonTypeTest {
   @Test
   fun testReasonTypeEnumValues() {
     // Verify all expected reason types are present in the enum
-    val expectedValues = setOf(
-      ReasonType.TARGET,
-      ReasonType.RULE,
-      ReasonType.DEFAULT,
-      @Suppress("DEPRECATION")
-      ReasonType.CLIENT,
-      ReasonType.OFF_VARIATION,
-      ReasonType.PREREQUISITE,
-      ReasonType.ERROR_NO_EVALUATIONS,
-      ReasonType.ERROR_FLAG_NOT_FOUND,
-      ReasonType.ERROR_WRONG_TYPE,
-      ReasonType.ERROR_USER_ID_NOT_SPECIFIED,
-      ReasonType.ERROR_FEATURE_FLAG_ID_NOT_SPECIFIED,
-      ReasonType.ERROR_EXCEPTION,
-      ReasonType.ERROR_CACHE_NOT_FOUND,
-    )
+    val expectedValues =
+      setOf(
+        ReasonType.TARGET,
+        ReasonType.RULE,
+        ReasonType.DEFAULT,
+        @Suppress("DEPRECATION")
+        ReasonType.CLIENT,
+        ReasonType.OFF_VARIATION,
+        ReasonType.PREREQUISITE,
+        ReasonType.ERROR_NO_EVALUATIONS,
+        ReasonType.ERROR_FLAG_NOT_FOUND,
+        ReasonType.ERROR_WRONG_TYPE,
+        ReasonType.ERROR_USER_ID_NOT_SPECIFIED,
+        ReasonType.ERROR_FEATURE_FLAG_ID_NOT_SPECIFIED,
+        ReasonType.ERROR_EXCEPTION,
+        ReasonType.ERROR_CACHE_NOT_FOUND,
+      )
 
     val actualValues = ReasonType.values().toSet()
     assertEquals(expectedValues, actualValues)


### PR DESCRIPTION
Introduces explicit error reason types (e.g., ERROR_FLAG_NOT_FOUND, ERROR_WRONG_TYPE) to both public and internal enums for feature flag evaluation results. Updates event tracking and evaluation logic to use these new error types, deprecates the generic CLIENT reason, and adds/updates tests to cover the new reason types and their parsing behavior.