### PR TITLE
ci: update maven central new plugin settings params

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -32,5 +32,6 @@ POM_DEVELOPER_ID=bucketeer-bot
 POM_DEVELOPER_NAME=Bucketeer Bot
 POM_DEVELOPER_EMAIL=bucketeer@cyberagent.co.jp
 #
-SONATYPE_AUTOMATIC_RELEASE=true
-RELEASE_SIGNING_ENABLED=true
+mavenCentralAutomaticPublishing=true
+signAllPublications=true
+mavenCentralPublishing=true


### PR DESCRIPTION
fix https://github.com/bucketeer-io/android-client-sdk/actions/runs/25161773652/job/73757790296

Added new Gradle properties: 
- `mavenCentralPublishing=true` replaces `SONATYPE_HOST=CENTRAL_PORTAL`. 
- `mavenCentralAutomaticPublishing=true` replaces `SONATYPE_AUTOMATIC_RELEASE=true`. 
- `signAllPublications=true` replaces `RELEASE_SIGNING_ENABLED=true`. 

That should fixed missing gradlew task `./gradlew :bucketeer:publishAllPublicationToMavenCentralRepository`
<img width="1136" height="239" alt="Screenshot 2026-04-30 at 18 57 23" src="https://github.com/user-attachments/assets/358fbeee-3d8e-45ee-a18a-6d49db503366" />


