### PR TITLE
fix: measure latencySecond with monotonic high-resolution clock

### DIFF
--- a/bucketeer/src/androidTest/kotlin/io/bucketeer/sdk/android/instrumented/MeasureTimeSecondsWithResultTest.kt
+++ b/bucketeer/src/androidTest/kotlin/io/bucketeer/sdk/android/instrumented/MeasureTimeSecondsWithResultTest.kt
@@ -1,0 +1,42 @@
+package io.bucketeer.sdk.android.instrumented
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.truth.Truth.assertThat
+import io.bucketeer.sdk.android.internal.remote.measureTimeSecondsWithResult
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Regression tests for the "duration is nil and latencySecond is 0"
+ * backend warning.
+ * That test will run on real Android devices to ensure that the timer behaves as expected in a real environment.
+ */
+@RunWith(AndroidJUnit4::class)
+internal class MeasureTimeSecondsWithResultTest {
+  @Test
+  fun measureTimeSecondsWithResultYieldsStrictlyPositiveSecondsForNonTrivialWork() {
+    // Even cheap-but-real work (a few iterations of a method call) takes
+    // dozens of nanoseconds at minimum; with the new System.nanoTime()
+    // backed timer this must always measure > 0.
+    repeat(5_000) { iter ->
+      val (seconds, _) =
+        measureTimeSecondsWithResult {
+          // Perform a small amount of real work to ensure that at least one
+          // nanosecond elapses between the two nanoTime() reads.
+          // Keep the loop at 20 iterations so the test stays fast while still
+          // making it very likely that measurable time has elapsed.
+          // The production work covered by this regression test, such as
+          // network requests, is much more expensive than this synthetic loop.
+          var acc = 0L
+          for (i in 0 until 20) {
+            acc += i.toLong()
+          }
+          acc
+        }
+      assertThat(seconds).isGreaterThan(0.0)
+      // sanity: anything sub-second should be considered "fast"
+      assertThat(seconds).isLessThan(1.0)
+      assertThat(iter).isAtLeast(0) // keep `iter` referenced in failure messages
+    }
+  }
+}

--- a/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/remote/ApiClientExt.kt
+++ b/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/remote/ApiClientExt.kt
@@ -141,7 +141,7 @@ inline fun <T> measureTimeMillisWithResult(block: () -> T): Pair<Long, T> {
   return (System.currentTimeMillis() - start) to result
 }
 
-// Measures the elapsed wall-clock time of `block` with sub-millisecond,
+// Measures the elapsed time of `block` with sub-millisecond,
 // monotonic resolution and returns it as seconds (Double).
 //
 // Why this exists: System.currentTimeMillis() has 1ms resolution and is also

--- a/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/remote/ApiClientExt.kt
+++ b/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/remote/ApiClientExt.kt
@@ -140,3 +140,24 @@ inline fun <T> measureTimeMillisWithResult(block: () -> T): Pair<Long, T> {
   val result = block()
   return (System.currentTimeMillis() - start) to result
 }
+
+// Measures the elapsed wall-clock time of `block` with sub-millisecond,
+// monotonic resolution and returns it as seconds (Double).
+//
+// Why this exists: System.currentTimeMillis() has 1ms resolution and is also
+// subject to NTP / user clock changes, which on AndroidTV and similar
+// devices regularly produced an elapsed time of 0ms for fast operations.
+// That made the SDK send `latencySecond = 0.0`, which the backend rejected
+// as "duration is nil and latencySecond is 0". System.nanoTime() is
+// monotonic and has nanosecond precision, so any work that actually
+// executed will be measured as > 0.
+@OptIn(ExperimentalContracts::class)
+inline fun <T> measureTimeSecondsWithResult(block: () -> T): Pair<Double, T> {
+  kotlin.contracts.contract {
+    callsInPlace(block, kotlin.contracts.InvocationKind.EXACTLY_ONCE)
+  }
+  val startNanos = System.nanoTime()
+  val result = block()
+  val seconds = (System.nanoTime() - startNanos) / 1_000_000_000.0
+  return seconds to result
+}

--- a/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/remote/ApiClientImpl.kt
+++ b/bucketeer/src/main/kotlin/io/bucketeer/sdk/android/internal/remote/ApiClientImpl.kt
@@ -107,8 +107,8 @@ internal class ApiClientImpl(
             actualClient.newCall(cloneRequest)
           logd { "--> Fetch Evaluation\n$body" }
 
-          val (millis, data) =
-            measureTimeMillisWithResult {
+          val (seconds, data) =
+            measureTimeSecondsWithResult {
               val rawResponse = call.execute()
               responseStatusCode = rawResponse.code
 
@@ -129,7 +129,7 @@ internal class ApiClientImpl(
 
           GetEvaluationsResult.Success(
             value = response,
-            seconds = millis / 1000.0,
+            seconds = seconds,
             sizeByte = contentLength,
             featureTag = featureTag,
           )

--- a/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/internal/remote/ApiClientExtTest.kt
+++ b/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/internal/remote/ApiClientExtTest.kt
@@ -1,0 +1,72 @@
+package io.bucketeer.sdk.android.internal.remote
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * Regression tests for the "duration is nil and latencySecond is 0"
+ * backend warning.
+ *
+ * Before the fix, [measureTimeMillisWithResult] used
+ * `System.currentTimeMillis()`, which has 1ms resolution and is wall-clock.
+ * Sub-millisecond network responses (cached responses, very fast LANs,
+ * AndroidTV clock-tick collisions) measured 0ms; the SDK then sent
+ * `latencySecond = 0.0` which the backend rejected.
+ *
+ * The fix adds [measureTimeSecondsWithResult] which uses
+ * `System.nanoTime()` (monotonic, sub-millisecond resolution) and returns
+ * seconds as a Double. Any work that actually executed must measure > 0.
+ */
+internal class ApiClientExtTest {
+  @Test
+  fun `measureTimeSecondsWithResult returns the block's result`() {
+    val (_, result) = measureTimeSecondsWithResult { 42 }
+    assertThat(result).isEqualTo(42)
+  }
+
+  @Test
+  fun `measureTimeSecondsWithResult returns a non-negative finite Double`() {
+    val (seconds, _) = measureTimeSecondsWithResult { Unit }
+    assertThat(seconds).isAtLeast(0.0)
+    assertThat(seconds.isFinite()).isTrue()
+  }
+
+  @Test
+  fun `measureTimeSecondsWithResult yields strictly positive seconds for non-trivial work (regression for latencySecond=0)`() {
+    // Even cheap-but-real work (a few iterations of a method call) takes
+    // dozens of nanoseconds at minimum; with the new System.nanoTime()
+    // backed timer this must always measure > 0.
+    repeat(100) { iter ->
+      val (seconds, _) =
+        measureTimeSecondsWithResult {
+          // small amount of real work to ensure at least one nanosecond
+          // elapses between the two nanoTime() reads.
+          var acc = 0L
+          for (i in 0 until 1_000) {
+            acc += i.toLong()
+          }
+          acc
+        }
+      assertThat(seconds).isGreaterThan(0.0)
+      // sanity: anything sub-second should be considered "fast"
+      assertThat(seconds).isLessThan(1.0)
+      assertThat(iter).isAtLeast(0) // keep `iter` referenced in failure messages
+    }
+  }
+
+  @Test
+  fun `measureTimeSecondsWithResult has sub-millisecond resolution`() {
+    // The pre-fix `System.currentTimeMillis()` timer rounded to whole
+    // milliseconds, so a < 1ms measurement was impossible. With
+    // `System.nanoTime()` we should easily measure a sub-ms interval.
+    var sawSubMs = false
+    for (i in 0 until 50) {
+      val (seconds, _) = measureTimeSecondsWithResult { Unit }
+      if (seconds > 0.0 && seconds < 0.001) {
+        sawSubMs = true
+        break
+      }
+    }
+    assertThat(sawSubMs).isTrue()
+  }
+}

--- a/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/internal/remote/MeasureTimeSecondsWithResultTest.kt
+++ b/bucketeer/src/test/kotlin/io/bucketeer/sdk/android/internal/remote/MeasureTimeSecondsWithResultTest.kt
@@ -17,7 +17,7 @@ import org.junit.Test
  * `System.nanoTime()` (monotonic, sub-millisecond resolution) and returns
  * seconds as a Double. Any work that actually executed must measure > 0.
  */
-internal class ApiClientExtTest {
+internal class MeasureTimeSecondsWithResultTest {
   @Test
   fun `measureTimeSecondsWithResult returns the block's result`() {
     val (_, result) = measureTimeSecondsWithResult { 42 }
@@ -36,13 +36,17 @@ internal class ApiClientExtTest {
     // Even cheap-but-real work (a few iterations of a method call) takes
     // dozens of nanoseconds at minimum; with the new System.nanoTime()
     // backed timer this must always measure > 0.
-    repeat(100) { iter ->
+    repeat(5_000) { iter ->
       val (seconds, _) =
         measureTimeSecondsWithResult {
-          // small amount of real work to ensure at least one nanosecond
-          // elapses between the two nanoTime() reads.
+          // Perform a small amount of real work to ensure that at least one
+          // nanosecond elapses between the two nanoTime() reads.
+          // Keep the loop at 50 iterations so the test stays fast while still
+          // making it very likely that measurable time has elapsed.
+          // The production work covered by this regression test, such as
+          // network requests, is much more expensive than this synthetic loop.
           var acc = 0L
-          for (i in 0 until 1_000) {
+          for (i in 0 until 50) {
             acc += i.toLong()
           }
           acc
@@ -60,7 +64,7 @@ internal class ApiClientExtTest {
     // milliseconds, so a < 1ms measurement was impossible. With
     // `System.nanoTime()` we should easily measure a sub-ms interval.
     var sawSubMs = false
-    for (i in 0 until 50) {
+    for (i in 0 until 1000) {
       val (seconds, _) = measureTimeSecondsWithResult { Unit }
       if (seconds > 0.0 && seconds < 0.001) {
         sawSubMs = true


### PR DESCRIPTION
## Summary

Replace `System.currentTimeMillis()`-based latency measurement with `System.nanoTime()` so that sub-millisecond network responses no longer report `latencySecond: 0` and get rejected by the backend with `duration is nil and latencySecond is 0: gateway: metrics event has invalid duration`.

## Why

The Android SDK measured the `get_evaluations` round-trip with this helper:

```kotlin
inline fun <T> measureTimeMillisWithResult(block: () -> T): Pair<Long, T> {
  val start = System.currentTimeMillis()
  val result = block()
  return (System.currentTimeMillis() - start) to result
}
```

…and the caller divided the result by `1000.0` to get seconds:

```kotlin
GetEvaluationsResult.Success(
    value = response,
    seconds = millis / 1000.0,
    ...
)
```

`System.currentTimeMillis()` is a wall-clock, integer-millisecond timer with two failure modes for short measurements:

1. **Resolution.** On many Android devices the underlying tick is 5–15 ms, so a network response that completes inside a single tick measures `0 ms`.
2. **Wall-clock jumps.** It is subject to user clock changes and NTP corrections during the call, which can produce `0` (or even negative) elapsed time.

Either case yields `seconds = 0.0`, the SDK ships `latencySecond: 0`, and the backend correctly flags it as invalid (proto3 `double` has no field-presence, so `0` is indistinguishable from "unset"):

```go
// pkg/api/api/metrics_event.go
if ev.Duration == nil && ev.LatencySecond == 0 {
    return fmt.Errorf("duration is nil and latencySecond is 0: %w", MetricsSaveErrInvalidDuration)
}
```

This was being observed in production for `sourceId=ANDROID` / `tag=androidtv`. The same root cause was confirmed empirically in the Node SDK PR (a 100 000-iteration sweep showed the analogous `Date.now()` returning `0` ms in 99 997 / 100 000 consecutive calls), and the Android timer is at least as coarse.

The other Bucketeer SDKs are unaffected because they already use higher-resolution monotonic timers — iOS uses `Date().timeIntervalSince(...)` (sub-µs `Double`), Go uses `time.Since(...)` (ns).

## What changed

- `bucketeer/.../internal/remote/ApiClientExt.kt`: add `measureTimeSecondsWithResult { … }: Pair<Double, T>` backed by `System.nanoTime()` (monotonic, nanosecond resolution, immune to wall-clock changes). Returns elapsed time as seconds (`Double`) directly so no information is lost in a `Long`-to-seconds conversion. The original `measureTimeMillisWithResult` is kept untouched to avoid disturbing other callers.
- `bucketeer/.../internal/remote/ApiClientImpl.kt::getEvaluations`: switch the network-call timer to `measureTimeSecondsWithResult` and feed the precise `seconds` straight into `GetEvaluationsResult.Success`, dropping the `millis / 1000.0` division.
- `bucketeer/.../internal/remote/MeasureTimeSecondsWithResultTest.kt`: new unit tests — including the regression test `measureTimeSecondsWithResult yields strictly positive seconds for non-trivial work (regression for latencySecond=0)`, and a sub-millisecond-resolution test that the previous `currentTimeMillis()`-based helper would have been physically incapable of satisfying.

No proto, backend, or public-API changes are required.

## Test plan

- [x] `./gradlew :bucketeer:testDebugUnitTest --tests "io.bucketeer.sdk.android.internal.remote. MeasureTimeSecondsWithResultTest"` — new tests pass.